### PR TITLE
Require HEARTBEAT_OK on its own line to trigger heartbeat handling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,7 +19,7 @@ import type {
   ImageAttachment,
 } from "@/types/chat";
 import { getTextFromContent, getMessageSide, formatMessageTime, updateAt, updateMessageById } from "@/lib/messageUtils";
-import { HEARTBEAT_MARKER, NO_REPLY_MARKER, SYSTEM_PREFIX, SYSTEM_MESSAGE_PREFIX, GATEWAY_INJECTED_MODEL, WS_HELLO_OK, STOP_REASON_INJECTED, isToolCallPart, SPAWN_TOOL_NAME, hasUnquotedMarker } from "@/lib/constants";
+import { HEARTBEAT_MARKER, NO_REPLY_MARKER, SYSTEM_PREFIX, SYSTEM_MESSAGE_PREFIX, GATEWAY_INJECTED_MODEL, WS_HELLO_OK, STOP_REASON_INJECTED, isToolCallPart, SPAWN_TOOL_NAME, hasUnquotedMarker, hasHeartbeatOnOwnLine } from "@/lib/constants";
 import { requestNotificationPermission, notifyMessageComplete } from "@/lib/notifications";
 import { loadOrCreateDeviceIdentity, signDevicePayload, buildDeviceAuthPayload } from "@/lib/deviceIdentity";
 import { parseConfigProviders, mergeModels } from "@/lib/parseBackendModels";
@@ -291,7 +291,7 @@ export default function Home() {
     );
     const preview = msg ? getTextFromContent(msg.content) : "";
     // Skip notification for silent injected messages
-    if (preview.includes(HEARTBEAT_MARKER) || hasUnquotedMarker(preview, NO_REPLY_MARKER)) return;
+    if (hasHeartbeatOnOwnLine(preview) || hasUnquotedMarker(preview, NO_REPLY_MARKER)) return;
     notifyMessageComplete(preview);
   }, []);
 
@@ -467,7 +467,7 @@ export default function Home() {
         let isContext = false;
         if (m.role === "user" && Array.isArray(filteredContent)) {
           const tp = filteredContent.find((p) => p.type === "text" && p.text);
-          if (tp?.text && typeof tp.text === "string" && (tp.text.startsWith(SYSTEM_PREFIX) || tp.text.startsWith(SYSTEM_MESSAGE_PREFIX) || tp.text.includes(HEARTBEAT_MARKER))) isContext = true;
+          if (tp?.text && typeof tp.text === "string" && (tp.text.startsWith(SYSTEM_PREFIX) || tp.text.startsWith(SYSTEM_MESSAGE_PREFIX) || hasHeartbeatOnOwnLine(tp.text))) isContext = true;
         }
 
         const isGatewayInjected = m.model === GATEWAY_INJECTED_MODEL;
@@ -1548,7 +1548,7 @@ export default function Home() {
       if (
         msg.role === "assistant" &&
         msgText &&
-        (msgText.includes(HEARTBEAT_MARKER) || hasUnquotedMarker(msgText, NO_REPLY_MARKER)) &&
+        (hasHeartbeatOnOwnLine(msgText) || hasUnquotedMarker(msgText, NO_REPLY_MARKER)) &&
         result.length > 0
       ) {
         // Absorb ALL consecutive preceding assistant messages into this one

--- a/components/MessageRow.tsx
+++ b/components/MessageRow.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import type { ContentPart, Message } from "@/types/chat";
 import { getTextFromContent, getImages, thinkingPreview } from "@/lib/messageUtils";
-import { HEARTBEAT_MARKER, NO_REPLY_MARKER, SYSTEM_PREFIX, SYSTEM_MESSAGE_PREFIX, STOP_REASON_INJECTED, isToolCallPart, SPAWN_TOOL_NAME, hasUnquotedMarker } from "@/lib/constants";
+import { HEARTBEAT_MARKER, NO_REPLY_MARKER, SYSTEM_PREFIX, SYSTEM_MESSAGE_PREFIX, STOP_REASON_INJECTED, isToolCallPart, SPAWN_TOOL_NAME, hasUnquotedMarker, hasHeartbeatOnOwnLine } from "@/lib/constants";
 import { useExpandablePanel } from "@/hooks/useExpandablePanel";
 import { SlideContent } from "@/components/SlideContent";
 import { MarkdownContent } from "@/components/markdown/MarkdownContent";
@@ -73,7 +73,7 @@ function InjectedIcon({ type }: { type: "heartbeat" | "no_reply" | "info" }) {
 }
 
 function getInjectedSummary(text: string): { type: "heartbeat" | "no_reply" | "info"; summary: string } {
-  if (text.includes(HEARTBEAT_MARKER)) {
+  if (hasHeartbeatOnOwnLine(text)) {
     // Last sentence before HEARTBEAT_OK
     const before = text.slice(0, text.indexOf(HEARTBEAT_MARKER)).trim();
     const sentences = before.match(/[^.!?\n]+[.!?]?/g);
@@ -445,7 +445,7 @@ export function MessageRow({ message, isStreaming, subagentStore, pinnedToolCall
   }
 
   // HEARTBEAT_OK / NO_REPLY assistant messages — render as injected pill
-  if (message.role === "assistant" && text && (text.includes(HEARTBEAT_MARKER) || hasUnquotedMarker(text, NO_REPLY_MARKER))) {
+  if (message.role === "assistant" && text && (hasHeartbeatOnOwnLine(text) || hasUnquotedMarker(text, NO_REPLY_MARKER))) {
     return <InjectedPill text={text} message={message} subagentStore={subagentStore} />;
   }
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -2,6 +2,12 @@
 export const HEARTBEAT_MARKER = "HEARTBEAT_OK";
 export const NO_REPLY_MARKER = "NO_REPLY";
 
+/** Returns true only if HEARTBEAT_OK appears on a line by itself (nothing else on that line). */
+const HEARTBEAT_OWN_LINE_RE = new RegExp(`^${HEARTBEAT_MARKER}$`, "m");
+export function hasHeartbeatOnOwnLine(text: string): boolean {
+  return HEARTBEAT_OWN_LINE_RE.test(text);
+}
+
 /** Returns true only if `marker` appears in `text` outside of double-quoted strings. */
 export function hasUnquotedMarker(text: string, marker: string): boolean {
   let i = 0;

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { hasHeartbeatOnOwnLine, hasUnquotedMarker, HEARTBEAT_MARKER } from "@/lib/constants";
+
+describe("hasHeartbeatOnOwnLine", () => {
+  it("matches HEARTBEAT_OK as the entire text", () => {
+    expect(hasHeartbeatOnOwnLine("HEARTBEAT_OK")).toBe(true);
+  });
+
+  it("matches HEARTBEAT_OK on its own line in multiline text", () => {
+    expect(hasHeartbeatOnOwnLine("some text\nHEARTBEAT_OK")).toBe(true);
+    expect(hasHeartbeatOnOwnLine("HEARTBEAT_OK\nsome text")).toBe(true);
+    expect(hasHeartbeatOnOwnLine("line one\nHEARTBEAT_OK\nline three")).toBe(true);
+  });
+
+  it("does not match HEARTBEAT_OK embedded in a sentence", () => {
+    expect(hasHeartbeatOnOwnLine("I should reply HEARTBEAT_OK")).toBe(false);
+    expect(hasHeartbeatOnOwnLine("HEARTBEAT_OK is a marker")).toBe(false);
+    expect(hasHeartbeatOnOwnLine("send HEARTBEAT_OK now")).toBe(false);
+  });
+
+  it("does not match HEARTBEAT_OK with surrounding whitespace on the line", () => {
+    // Trailing/leading spaces on the same line should NOT match
+    expect(hasHeartbeatOnOwnLine("  HEARTBEAT_OK")).toBe(false);
+    expect(hasHeartbeatOnOwnLine("HEARTBEAT_OK  ")).toBe(false);
+  });
+
+  it("does not match partial occurrences", () => {
+    expect(hasHeartbeatOnOwnLine("HEARTBEAT_OK_EXTRA")).toBe(false);
+    expect(hasHeartbeatOnOwnLine("MY_HEARTBEAT_OK")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(hasHeartbeatOnOwnLine("")).toBe(false);
+  });
+
+  it("returns false when marker is absent", () => {
+    expect(hasHeartbeatOnOwnLine("just some normal text")).toBe(false);
+  });
+});


### PR DESCRIPTION
Previously any occurrence of HEARTBEAT_OK in message text (e.g. "I should
reply HEARTBEAT_OK") would be treated as a heartbeat. Now the marker must
appear on a separate line with nothing else on it.

https://claude.ai/code/session_01BvRX2qeD7uCyye8w6qFqze