### PR TITLE
Add live canvas plugins for inline chat widgets

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -552,7 +552,8 @@ export default forwardRef<ChatInputHandle>(function Home(_props, forwardedRef) {
   useImperativeHandle(forwardedRef, () => ({
     setValue: (v: string) => chatInputRef.current?.setValue(v),
     addInputAttachment: (kind: string, data: unknown) => add(kind, data),
-  }), [add]);
+    sendCommand: (text: string) => void sendMessage(text),
+  }), [add, sendMessage]);
 
   const {
     queuedMessage,

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -18,6 +18,7 @@ export interface ModelSuggestion {
 export interface ChatInputHandle {
   setValue: (v: string) => void;
   addInputAttachment: (kind: string, data: unknown) => void;
+  sendCommand?: (text: string) => void;
 }
 
 export const ChatInput = forwardRef<ChatInputHandle, {

--- a/components/chat/ChatViewport.tsx
+++ b/components/chat/ChatViewport.tsx
@@ -735,8 +735,19 @@ export function ChatViewport({
         className={`scrollbar-hide ${useDocumentScroll ? "overflow-visible" : "flex-1 overflow-y-auto overflow-x-hidden"} ${isNative || detachedNoBorder ? "" : "bg-background"} ${detachedShell ? "rounded-2xl" : (!isDetached ? "pt-14" : "")}`}
         style={{ ...(isNative || useDocumentScroll ? {} : { overscrollBehavior: "none" as const }), ...(detachedShell ? { boxShadow: "0 -4px 6px -1px rgb(0 0 0 / 0.06), 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)" } : {}) }}
       >
-        <div className={`mx-auto flex w-full ${isDetached || isNative ? "max-w-none" : "max-w-2xl"} flex-col gap-3 px-4 py-6 md:px-6 md:py-4 transition-opacity duration-300 ease-out ${historyLoaded ? "opacity-100" : "opacity-0"}`} style={{ paddingBottom: bottomPad }}>
+        <div className={`mx-auto flex w-full ${isDetached || isNative ? "max-w-none" : "max-w-2xl"} flex-col gap-3 px-4 pt-16 pb-6 md:px-6 md:pt-24 md:pb-4 transition-opacity duration-300 ease-out ${historyLoaded ? "opacity-100" : "opacity-0"} ${historyLoaded && zenDisplayMessages.length === 0 ? "min-h-full" : ""}`} style={{ paddingBottom: bottomPad }}>
           {isNative && <div aria-hidden="true" style={{ height: IOS_TOP_MESSAGE_SPACER_HEIGHT, flexShrink: 0 }} />}
+          {historyLoaded && zenDisplayMessages.length === 0 && (
+            <div className="flex flex-1 flex-col items-center justify-center gap-6">
+              <p className="text-center px-8 text-sm leading-relaxed max-w-sm" style={{ color: "#C8C8C8" }}>
+                Welcome to 8Claw. Send a message to start your first conversation. You can ask your agent anything from general questions to asking it to create automated tools for you.
+              </p>
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#C8C8C8" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 5v14" />
+                <path d="m19 12-7 7-7-7" />
+              </svg>
+            </div>
+          )}
           {zenDisplayMessages.map((msg, idx) => {
             const toolGroupHead = toolGroupMap.get(idx) ?? -1;
             const side = getMessageSide(msg.role);

--- a/hooks/useScrollManager.ts
+++ b/hooks/useScrollManager.ts
@@ -347,22 +347,10 @@ export function useScrollManager({
       if (isAnimatingScrollRef.current) return;
 
       if (isStreamingRef.current) {
-        // During streaming, only allow content to grow — never shrink.
-        // This prevents zen collapses from reducing scrollHeight and causing
-        // the scroll position to jump back up.
-        const currentHeight = content.offsetHeight;
-        const prevMin = parseFloat(content.style.minHeight) || 0;
-        if (currentHeight > prevMin) {
-          content.style.minHeight = `${currentHeight}px`;
-        }
+        // During streaming, let the rAF momentum loop handle scroll position.
+        // Don't lock minHeight — content must be free to shrink when the user
+        // collapses a tool call.
         return;
-      }
-
-      // During grace period, keep the streaming height lock and let the rAF
-      // momentum loop handle scroll smoothly. The rAF tick will clear minHeight
-      // once grace expires.
-      if (!scrollGraceRef.current) {
-        content.style.minHeight = "";
       }
 
       if ((pinnedToBottomRef.current || scrollGraceRef.current) && el.scrollHeight > getViewportHeight(el)) {
@@ -397,7 +385,6 @@ export function useScrollManager({
     // velocity in px-per-60fps-frame; multiplied by frameScale before applying
     let velocity = 0;
     let lastTime = 0;
-    let wasStreaming = isStreamingRef.current;
 
     // Tuning constants (normalized to 60fps baseline)
     const TARGET_FRAME_MS = 16.67;      // 60fps reference frame duration
@@ -406,21 +393,7 @@ export function useScrollManager({
     const SCROLL_MOMENTUM_FACTOR = 0.12; // per-frame blend toward desired velocity (60fps)
     const SCROLL_MIN_VELOCITY = 0.5;     // px/frame minimum while actively scrolling
 
-    let pendingMinHeightClear = false;
-
     const tick = (timestamp: number) => {
-      if (wasStreaming && !isStreamingRef.current) {
-        // Don't clear minHeight immediately — defer until after the grace period
-        // so content height stays stable during smooth scroll wind-down.
-        pendingMinHeightClear = true;
-      }
-      if (pendingMinHeightClear && !scrollGraceRef.current) {
-        const content = el.firstElementChild as HTMLElement | null;
-        if (content) content.style.minHeight = "";
-        pendingMinHeightClear = false;
-      }
-      wasStreaming = isStreamingRef.current;
-
       const rawDelta = lastTime ? timestamp - lastTime : TARGET_FRAME_MS;
       // Clamp to 50ms to prevent huge jumps after tab switch or system sleep
       const deltaTime = Math.min(rawDelta, 50);

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/plugins/app/flowCanvasCard.tsx
+++ b/plugins/app/flowCanvasCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { z } from "zod";
 import type { MobileClawPlugin, PluginViewProps } from "@mc/lib/plugins/types";
 
@@ -28,7 +29,7 @@ type StepEntry = z.infer<typeof stepSchema>;
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-function stepTypeIcon(type: string): React.ReactNode {
+function stepTypeIcon(type: string): ReactNode {
   switch (type) {
     case "trigger":
       return (

--- a/plugins/app/flowCanvasCard.tsx
+++ b/plugins/app/flowCanvasCard.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { z } from "zod";
+import type { MobileClawPlugin, PluginViewProps } from "@mc/lib/plugins/types";
+
+// ── Schema ──────────────────────────────────────────────────────────────────
+
+const stepSchema = z.object({
+  name: z.string(),
+  displayName: z.string(),
+  type: z.enum(["trigger", "piece", "code", "loop", "router"]).default("piece"),
+  pieceName: z.string().optional(),
+  stepNumber: z.number(),
+  valid: z.boolean().default(true),
+  highlighted: z.boolean().optional(),
+});
+
+const flowCanvasCardSchema = z.object({
+  flowId: z.string(),
+  displayName: z.string(),
+  status: z.string().optional(),
+  steps: z.array(stepSchema),
+  highlightedSteps: z.array(z.string()).optional(),
+});
+
+type FlowCanvasCardData = z.infer<typeof flowCanvasCardSchema>;
+type StepEntry = z.infer<typeof stepSchema>;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function stepTypeIcon(type: string): React.ReactNode {
+  switch (type) {
+    case "trigger":
+      return (
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+          <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+        </svg>
+      );
+    case "code":
+      return (
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="16 18 22 12 16 6" /><polyline points="8 6 2 12 8 18" />
+        </svg>
+      );
+    case "loop":
+      return (
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M17 2l4 4-4 4" /><path d="M3 11v-1a4 4 0 0 1 4-4h14" />
+          <path d="M7 22l-4-4 4-4" /><path d="M21 13v1a4 4 0 0 1-4 4H3" />
+        </svg>
+      );
+    case "router":
+      return (
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M16 3h5v5" /><path d="M8 3H3v5" />
+          <path d="M12 22v-8.3a4 4 0 0 0-1.172-2.872L3 3" />
+          <path d="m15 9 6-6" />
+        </svg>
+      );
+    default: // piece
+      return (
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76Z" />
+        </svg>
+      );
+  }
+}
+
+function friendlyPieceName(pieceName?: string): string | null {
+  if (!pieceName) return null;
+  const match = pieceName.match(/piece-(.+)$/);
+  return match ? match[1] : pieceName;
+}
+
+// ── Compact Step Node ───────────────────────────────────────────────────────
+
+function StepNode({ step, isHighlighted }: { step: StepEntry; isHighlighted: boolean }) {
+  const pieceName = friendlyPieceName(step.pieceName);
+
+  return (
+    <div
+      className={[
+        "rounded-lg border px-3 py-2 bg-card/90 transition-shadow",
+        !step.valid ? "border-destructive/30 bg-destructive/5" : "border-border",
+        isHighlighted ? "ring-2 ring-amber-400/60 shadow-sm" : "",
+      ].join(" ")}
+    >
+      <div className="flex items-center gap-2.5">
+        {/* Step number */}
+        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-[10px] font-medium bg-secondary text-secondary-foreground">
+          {step.stepNumber}
+        </span>
+
+        {/* Type icon */}
+        <div className="shrink-0 text-muted-foreground">
+          {stepTypeIcon(step.type)}
+        </div>
+
+        {/* Name */}
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-medium text-foreground truncate">{step.displayName}</div>
+          {pieceName && (
+            <div className="text-[10px] text-muted-foreground truncate">{pieceName}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Edge connector ──────────────────────────────────────────────────────────
+
+function Edge() {
+  return (
+    <div className="flex flex-col items-center py-0.5">
+      <div className="h-4 w-px bg-border" />
+      <div className="-mt-0.5 h-2.5 w-2.5 rounded-full border border-border bg-card" />
+      <div className="-mt-0.5 h-4 w-px bg-border" />
+    </div>
+  );
+}
+
+// ── View ────────────────────────────────────────────────────────────────────
+
+function FlowCanvasCardView({ state, data }: PluginViewProps<FlowCanvasCardData>) {
+  if (state === "tombstone") {
+    return (
+      <div className="rounded-2xl border border-dashed border-border bg-card/50 px-3.5 py-3">
+        <div className="text-sm text-muted-foreground">Flow no longer available</div>
+      </div>
+    );
+  }
+
+  const highlightSet = new Set(data.highlightedSteps ?? []);
+  // Also check per-step highlighted flag
+  const isHighlighted = (step: StepEntry) =>
+    step.highlighted || highlightSet.has(step.name);
+
+  const statusDot = data.status === "ENABLED"
+    ? "bg-emerald-500"
+    : "bg-muted-foreground/40";
+
+  return (
+    <div className="rounded-2xl border border-border bg-card/80 overflow-hidden">
+      {/* Header */}
+      <div className="px-3.5 py-2.5 border-b border-border/60">
+        <div className="flex items-center gap-2.5">
+          <div className={`h-2 w-2 shrink-0 rounded-full ${statusDot}`} />
+          <span className="text-sm font-medium text-foreground truncate">{data.displayName}</span>
+          <span className="text-[10px] text-muted-foreground ml-auto">
+            {data.steps.length} step{data.steps.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+      </div>
+
+      {/* Flow visualization */}
+      <div className="px-3.5 py-3 max-h-[400px] overflow-y-auto">
+        <div className="flex flex-col items-center">
+          {data.steps.map((step, i) => (
+            <div key={step.name} className="w-full max-w-[280px]">
+              {i > 0 && <Edge />}
+              <StepNode step={step} isHighlighted={isHighlighted(step)} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Plugin definition ───────────────────────────────────────────────────
+
+export const flowCanvasCardPlugin: MobileClawPlugin<FlowCanvasCardData> = {
+  type: "flow_canvas",
+  width: "chat",
+  parse: (raw) => {
+    const parsed = flowCanvasCardSchema.safeParse(raw);
+    if (!parsed.success) {
+      return { ok: false, error: parsed.error.issues[0]?.message || "Invalid flow canvas card payload" };
+    }
+    return { ok: true, value: parsed.data };
+  },
+  render: (props) => <FlowCanvasCardView {...props} />,
+};

--- a/plugins/app/flowListCard.tsx
+++ b/plugins/app/flowListCard.tsx
@@ -1,356 +1,148 @@
 "use client";
 
 import { z } from "zod";
+import type { MobileClawPlugin, PluginViewProps } from "@mc/lib/plugins/types";
 
-import type {
-  MobileClawPlugin,
-  PluginViewProps,
-} from "@mc/lib/plugins/types";
+// ── Schema ──────────────────────────────────────────────────────────────────
 
-/* ── Zod schema ── */
-
-const flowItemSchema = z.object({
+const flowEntrySchema = z.object({
   id: z.string(),
-  displayName: z.string().optional(),
+  displayName: z.string(),
   status: z.string().optional(),
   isPublished: z.boolean().optional(),
   triggerType: z.string().nullable().optional(),
   triggerPiece: z.string().nullable().optional(),
   updated: z.string().optional(),
-  lastRun: z
-    .object({
-      status: z.string(),
-      createdAt: z.string(),
-    })
-    .nullable()
-    .optional(),
+  lastRun: z.object({
+    status: z.string().optional(),
+    createdAt: z.string().optional(),
+  }).nullable().optional(),
 });
 
 const flowListCardSchema = z.object({
-  flows: z.array(flowItemSchema),
+  flows: z.array(flowEntrySchema),
   total: z.number().optional(),
 });
 
 type FlowListCardData = z.infer<typeof flowListCardSchema>;
 
-/* ── Shared helpers ── */
+// ── Helpers ─────────────────────────────────────────────────────────────────
 
-export function resolvePublishedState(flow: {
-  isPublished?: boolean;
-}): "draft" | "published" {
-  return flow.isPublished ? "published" : "draft";
+function statusDotClass(status?: string): string {
+  if (status === "ENABLED") return "bg-emerald-500";
+  if (status === "DISABLED") return "bg-muted-foreground/40";
+  return "bg-muted-foreground/40";
 }
 
-export function publishedLabel(state: "draft" | "published"): string {
-  return state === "published" ? "Live" : "Draft";
-}
-
-export function resolveTriggerLabel(flow: {
-  triggerPiece?: string | null;
-  triggerType?: string | null;
-}): string {
-  if (!flow.triggerPiece && !flow.triggerType) return "Unknown";
-  if (flow.triggerPiece === "@activepieces/piece-manual-trigger") return "Manual";
-  if (flow.triggerPiece === "@activepieces/piece-webhook") return "Webhook";
-  if (flow.triggerPiece) {
-    return flow.triggerPiece
-      .replace("@activepieces/piece-", "")
-      .split(/[-_]+/)
-      .filter(Boolean)
-      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-      .join(" ");
+function friendlyTrigger(triggerType?: string | null, triggerPiece?: string | null): string | null {
+  if (!triggerType && !triggerPiece) return null;
+  if (triggerPiece) {
+    // Extract short name: "@activepieces/piece-gmail" → "gmail"
+    const match = triggerPiece.match(/piece-(.+)$/);
+    return match ? match[1] : triggerPiece;
   }
-  if (flow.triggerType) {
-    return flow.triggerType
-      .toLowerCase()
-      .split("_")
-      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-      .join(" ");
+  if (triggerType === "WEBHOOK") return "webhook";
+  if (triggerType === "SCHEDULE") return "schedule";
+  return triggerType?.toLowerCase() ?? null;
+}
+
+function lastRunBadgeClass(status?: string): string {
+  switch (status) {
+    case "SUCCEEDED":
+      return "text-emerald-600 dark:text-emerald-400";
+    case "FAILED":
+    case "INTERNAL_ERROR":
+    case "TIMEOUT":
+      return "text-destructive";
+    case "RUNNING":
+      return "text-primary";
+    default:
+      return "text-muted-foreground";
   }
-  return "Unknown";
 }
 
-const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
-
-export function relativeTimeFromISO(isoDate: string | undefined): string {
-  if (!isoDate) return "";
-  const diffMs = new Date(isoDate).getTime() - Date.now();
-  const absMs = Math.abs(diffMs);
-  if (absMs < 60_000)
-    return rtf.format(Math.round(diffMs / 1_000), "second");
-  if (absMs < 3_600_000)
-    return rtf.format(Math.round(diffMs / 60_000), "minute");
-  if (absMs < 86_400_000)
-    return rtf.format(Math.round(diffMs / 3_600_000), "hour");
-  return rtf.format(Math.round(diffMs / 86_400_000), "day");
+function timeAgo(ts: string): string {
+  const diff = Date.now() - new Date(ts).getTime();
+  if (diff < 60_000) return "just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return `${Math.floor(diff / 86_400_000)}d ago`;
 }
 
-function LastRunIcon({ status }: { status: string }) {
-  if (status === "SUCCEEDED")
-    return (
-      <svg
-        width="10"
-        height="10"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="3"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="text-brand-success-text shrink-0"
-      >
-        <path d="m5 13 4 4L19 7" />
-      </svg>
-    );
-  if (status === "RUNNING" || status === "QUEUED")
-    return (
-      <svg
-        width="10"
-        height="10"
-        viewBox="0 0 24 24"
-        className="animate-spin text-brand-ongoing shrink-0"
-      >
-        <circle
-          cx="12"
-          cy="12"
-          r="10"
-          stroke="currentColor"
-          strokeWidth="3"
-          fill="none"
-          strokeDasharray="31.4 31.4"
-          strokeLinecap="round"
-        />
-      </svg>
-    );
-  if (
-    status === "FAILED" ||
-    status === "INTERNAL_ERROR" ||
-    status === "TIMEOUT"
-  )
-    return (
-      <svg
-        width="10"
-        height="10"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        className="text-brand-failure shrink-0"
-      >
-        <circle cx="12" cy="12" r="10" />
-        <line x1="15" y1="9" x2="9" y2="15" />
-        <line x1="9" y1="9" x2="15" y2="15" />
-      </svg>
-    );
-  if (status === "PAUSED")
-    return (
-      <svg
-        width="10"
-        height="10"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        className="text-brand-paused-text shrink-0"
-      >
-        <rect x="6" y="4" width="4" height="16" rx="1" />
-        <rect x="14" y="4" width="4" height="16" rx="1" />
-      </svg>
-    );
-  return null;
-}
+// ── View ────────────────────────────────────────────────────────────────────
 
-/* ── Shared inner component ── */
+function FlowListCardView({ state, data }: PluginViewProps<FlowListCardData>) {
+  if (state === "tombstone") {
+    return (
+      <div className="rounded-2xl border border-dashed border-border bg-card/50 px-3.5 py-3">
+        <div className="text-sm text-muted-foreground">Flow list no longer available</div>
+      </div>
+    );
+  }
 
-export interface FlowListCardInnerProps {
-  flows: Array<{
-    id: string;
-    displayName?: string;
-    status?: string;
-    isPublished?: boolean;
-    triggerPiece?: string | null;
-    triggerType?: string | null;
-    updated?: string;
-    lastRun?: { status: string; createdAt: string } | null;
-  }>;
-  total?: number;
-  onFlowClick?: (flowId: string) => void;
-}
-
-export function FlowListCardInner({
-  flows,
-  total,
-  onFlowClick,
-}: FlowListCardInnerProps) {
-  const count = total ?? flows.length;
+  const { flows, total } = data;
+  const hasMore = total && total > flows.length;
 
   return (
-    <div className="overflow-hidden rounded-[24px] bg-card border border-border/50 shadow-[0_8px_24px_rgba(0,0,0,0.06)]">
+    <div className="rounded-2xl border border-border bg-card/80 overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between px-5 pt-4 pb-2">
-        <span className="text-[10px] font-bold tracking-[0.12em] uppercase text-muted-foreground">
-          Workflows
-        </span>
-        <span className="text-[11px] text-muted-foreground/60">
-          {count} flow{count !== 1 ? "s" : ""}
-        </span>
+      <div className="px-3.5 py-2.5 border-b border-border/60">
+        <div className="flex items-center gap-2">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className="text-muted-foreground shrink-0">
+            <path d="M16 3h5v5" /><path d="M8 3H3v5" />
+            <path d="M12 22v-8.3a4 4 0 0 0-1.172-2.872L3 3" />
+            <path d="m15 9 6-6" />
+          </svg>
+          <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+            Flows{total ? ` (${total})` : ""}
+          </span>
+        </div>
       </div>
 
-      {/* Flow items */}
-      <div className="divide-y divide-border/40">
-        {flows.map((flow) => {
-          const pubState = resolvePublishedState(flow);
-          const isEnabled = flow.status === "ENABLED";
-          const trigger = resolveTriggerLabel(flow);
-          const lastRunTime = flow.lastRun?.createdAt
-            ? relativeTimeFromISO(flow.lastRun.createdAt)
-            : null;
-
+      {/* List */}
+      <div className="max-h-[280px] overflow-y-auto">
+        {flows.map((flow, i) => {
+          const trigger = friendlyTrigger(flow.triggerType, flow.triggerPiece);
           return (
             <div
               key={flow.id}
-              className="flex items-center gap-3 px-5 py-3 transition-colors hover:bg-accent/30 cursor-pointer"
-              onClick={() => onFlowClick?.(flow.id)}
+              className={`px-3.5 py-2.5 flex items-center gap-3 ${
+                i < flows.length - 1 ? "border-b border-border/40" : ""
+              }`}
             >
-              {/* Published dot */}
-              <span
-                className={`size-2 rounded-full shrink-0 ${
-                  pubState === "published" && isEnabled
-                    ? "bg-foreground"
-                    : pubState === "published"
-                      ? "bg-foreground/40"
-                      : "border border-muted-foreground/40"
-                }`}
-              />
-
-              {/* Name + details */}
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="text-[13px] font-medium text-foreground truncate">
-                    {flow.displayName?.trim() || "Untitled workflow"}
-                  </span>
-                  <span
-                    className={`shrink-0 inline-flex items-center rounded-full px-1.5 py-0.5 text-[9px] font-bold tracking-[0.08em] uppercase ${
-                      pubState === "published"
-                        ? "bg-foreground text-background"
-                        : "border border-border text-muted-foreground"
-                    }`}
-                  >
-                    {publishedLabel(pubState)}
-                  </span>
-                </div>
-                <div className="flex items-center gap-1.5 mt-0.5 text-[11px] text-muted-foreground">
-                  <span>{trigger}</span>
-                  {lastRunTime && flow.lastRun ? (
-                    <>
-                      <span>&middot;</span>
-                      <span className="inline-flex items-center gap-1">
-                        <LastRunIcon status={flow.lastRun.status} />
-                        {lastRunTime}
-                      </span>
-                    </>
-                  ) : (
-                    <>
-                      <span>&middot;</span>
-                      <span className="text-muted-foreground/50">
-                        Never run
-                      </span>
-                    </>
+              <div className={`h-2 w-2 shrink-0 rounded-full ${statusDotClass(flow.status)}`} />
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-medium text-foreground truncate">{flow.displayName}</div>
+                <div className="flex items-center gap-2 mt-0.5">
+                  {trigger && (
+                    <span className="text-[10px] text-muted-foreground">{trigger}</span>
+                  )}
+                  {flow.lastRun?.status && (
+                    <span className={`text-[10px] ${lastRunBadgeClass(flow.lastRun.status)}`}>
+                      {flow.lastRun.status.toLowerCase()}
+                      {flow.lastRun.createdAt && ` ${timeAgo(flow.lastRun.createdAt)}`}
+                    </span>
                   )}
                 </div>
-              </div>
-
-              {/* Enabled indicator */}
-              <div
-                className={`size-6 rounded-full flex items-center justify-center shrink-0 ${
-                  isEnabled ? "bg-foreground" : "bg-muted-foreground/10"
-                }`}
-              >
-                {isEnabled ? (
-                  <svg
-                    width="10"
-                    height="10"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="3"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    className="text-background"
-                  >
-                    <path d="m5 13 4 4L19 7" />
-                  </svg>
-                ) : (
-                  <svg
-                    width="10"
-                    height="10"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2.5"
-                    strokeLinecap="round"
-                    className="text-muted-foreground/40"
-                  >
-                    <line x1="5" y1="12" x2="19" y2="12" />
-                  </svg>
-                )}
               </div>
             </div>
           );
         })}
       </div>
 
-      {/* Show more indicator */}
-      {total != null && total > flows.length && (
-        <div className="px-5 py-2.5 text-center text-[11px] text-muted-foreground/60 border-t border-border/40">
-          +{total - flows.length} more
+      {/* Footer */}
+      {hasMore && (
+        <div className="px-3.5 py-2 border-t border-border/60">
+          <span className="text-[10px] text-muted-foreground">
+            +{total! - flows.length} more
+          </span>
         </div>
       )}
     </div>
   );
 }
 
-/* ── Plugin view ── */
-
-function FlowListCardView({
-  state,
-  data,
-  addInputAttachment,
-}: PluginViewProps<FlowListCardData>) {
-  if (state === "tombstone") {
-    return (
-      <div
-        data-testid="flow-list-card"
-        className="rounded-2xl border border-dashed border-border bg-card/50 px-3.5 py-3"
-      >
-        <div className="text-sm text-muted-foreground">
-          Flow list no longer available.
-        </div>
-      </div>
-    );
-  }
-
-  const handleFlowClick = (flowId: string) => {
-    const flow = data.flows.find((f) => f.id === flowId);
-    addInputAttachment?.("flow", {
-      id: flowId,
-      displayName: flow?.displayName?.trim() || "Untitled",
-      status: flow?.status ?? "UNKNOWN",
-    });
-  };
-
-  return (
-    <div data-testid="flow-list-card">
-      <FlowListCardInner
-        flows={data.flows}
-        total={data.total}
-        onFlowClick={handleFlowClick}
-      />
-    </div>
-  );
-}
-
-/* ── Plugin definition ── */
+// ── Plugin definition ───────────────────────────────────────────────────
 
 export const flowListCardPlugin: MobileClawPlugin<FlowListCardData> = {
   type: "flow_list_card",
@@ -358,11 +150,7 @@ export const flowListCardPlugin: MobileClawPlugin<FlowListCardData> = {
   parse: (raw) => {
     const parsed = flowListCardSchema.safeParse(raw);
     if (!parsed.success) {
-      return {
-        ok: false,
-        error:
-          parsed.error.issues[0]?.message || "Invalid flow list payload",
-      };
+      return { ok: false, error: parsed.error.issues[0]?.message || "Invalid flow list card payload" };
     }
     return { ok: true, value: parsed.data };
   },

--- a/plugins/app/flowRunCard.tsx
+++ b/plugins/app/flowRunCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { type CSSProperties, useEffect, useMemo, useState } from "react";
 import { z } from "zod";
 import type { MobileClawPlugin, PluginViewProps } from "@mc/lib/plugins/types";
 
@@ -118,7 +118,7 @@ export interface FlowRunCardInnerProps {
   durationMs?: number;
   failedStep?: string;
   onClick?: () => void;
-  highlightStyle?: React.CSSProperties;
+  highlightStyle?: CSSProperties;
 }
 
 export function FlowRunCardInner({

--- a/plugins/app/flowRunCard.tsx
+++ b/plugins/app/flowRunCard.tsx
@@ -1,16 +1,10 @@
 "use client";
 
-import type { CSSProperties } from "react";
-import { useEffect, useState } from "react";
-
+import { useEffect, useMemo, useState } from "react";
 import { z } from "zod";
+import type { MobileClawPlugin, PluginViewProps } from "@mc/lib/plugins/types";
 
-import type {
-  MobileClawPlugin,
-  PluginViewProps,
-} from "@mc/lib/plugins/types";
-
-/* ── Zod schema ── */
+// ── Schema ──────────────────────────────────────────────────────────────────
 
 const flowRunCardSchema = z.object({
   runId: z.string(),
@@ -26,42 +20,18 @@ const flowRunCardSchema = z.object({
 
 type FlowRunCardData = z.infer<typeof flowRunCardSchema>;
 
-/* ── Shared helpers (exported for sidebar reuse) ── */
+// ── Helpers (exported for 8claw sidebar reuse) ──────────────────────────
 
-export function formatDuration(ms: number | null | undefined): string {
-  if (ms == null) return "\u2014";
-  if (ms < 1_000) return `${Math.round(ms)}ms`;
-  const totalSeconds = Math.round(ms / 1_000);
-  const seconds = totalSeconds % 60;
-  const minutes = Math.floor(totalSeconds / 60);
-  if (minutes > 0) return `${minutes}m ${seconds}s`;
-  return `${seconds}s`;
-}
-
-const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
-
-export function relativeTimeFromISO(isoDate: string | undefined): string {
-  if (!isoDate) return "";
-  const diffMs = new Date(isoDate).getTime() - Date.now();
-  const absMs = Math.abs(diffMs);
-  if (absMs < 60_000) return rtf.format(Math.round(diffMs / 1_000), "second");
-  if (absMs < 3_600_000)
-    return rtf.format(Math.round(diffMs / 60_000), "minute");
-  if (absMs < 86_400_000)
-    return rtf.format(Math.round(diffMs / 3_600_000), "hour");
-  return rtf.format(Math.round(diffMs / 86_400_000), "day");
-}
-
-export function isRunError(status: string): boolean {
-  return (
-    status === "FAILED" ||
-    status === "INTERNAL_ERROR" ||
-    status === "TIMEOUT" ||
-    status === "QUOTA_EXCEEDED" ||
-    status === "MEMORY_LIMIT_EXCEEDED" ||
-    status === "LOG_SIZE_EXCEEDED" ||
-    status === "CANCELED"
-  );
+export function resolveDurationMs(run: {
+  startTime?: string | null;
+  finishTime?: string | null;
+  duration?: number | null;
+}): number | null {
+  const start = run.startTime ? new Date(run.startTime).getTime() : null;
+  const finish = run.finishTime ? new Date(run.finishTime).getTime() : null;
+  if (start && finish && finish >= start) return finish - start;
+  if (typeof run.duration === "number" && run.duration >= 0) return run.duration;
+  return null;
 }
 
 export function resolveFailedStep(value: unknown): string | null {
@@ -74,54 +44,70 @@ export function resolveFailedStep(value: unknown): string | null {
   return null;
 }
 
-export function resolveDurationMs(run: {
-  startTime?: string;
-  finishTime?: string;
-  duration?: number | null;
-}): number | null {
-  const startMs = run.startTime
-    ? new Date(run.startTime).getTime()
-    : null;
-  const finishMs = run.finishTime
-    ? new Date(run.finishTime).getTime()
-    : null;
-  if (startMs && finishMs && finishMs >= startMs) return finishMs - startMs;
-  if (
-    typeof run.duration === "number" &&
-    Number.isFinite(run.duration) &&
-    run.duration >= 0
-  )
-    return run.duration;
-  return null;
+function formatDuration(ms?: number | null): string | null {
+  if (!ms || ms <= 0) return null;
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
 }
 
-function useElapsedSeconds(
-  startTime: string | undefined,
-  active: boolean,
-): number {
-  const [elapsed, setElapsed] = useState(() => {
-    if (!startTime) return 0;
-    return Math.max(
-      0,
-      Math.round((Date.now() - new Date(startTime).getTime()) / 1_000),
-    );
-  });
-  useEffect(() => {
-    if (!active || !startTime) return;
-    const id = window.setInterval(() => {
-      setElapsed(
-        Math.max(
-          0,
-          Math.round((Date.now() - new Date(startTime).getTime()) / 1_000),
-        ),
-      );
-    }, 1_000);
-    return () => window.clearInterval(id);
-  }, [active, startTime]);
-  return elapsed;
+function statusColor(status: string): string {
+  switch (status) {
+    case "RUNNING":
+    case "QUEUED":
+      return "text-primary";
+    case "SUCCEEDED":
+      return "text-emerald-600 dark:text-emerald-400";
+    case "FAILED":
+    case "INTERNAL_ERROR":
+    case "TIMEOUT":
+      return "text-destructive";
+    case "PAUSED":
+      return "text-amber-600 dark:text-amber-400";
+    default:
+      return "text-muted-foreground";
+  }
 }
 
-/* ── Shared inner component ── */
+function statusBgClass(status: string): string {
+  switch (status) {
+    case "RUNNING":
+    case "QUEUED":
+      return "border-primary/20 bg-primary/10 text-primary";
+    case "SUCCEEDED":
+      return "border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400";
+    case "FAILED":
+    case "INTERNAL_ERROR":
+    case "TIMEOUT":
+      return "border-destructive/20 bg-destructive/10 text-destructive";
+    case "PAUSED":
+      return "border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-400";
+    default:
+      return "border-border bg-background/60 text-muted-foreground";
+  }
+}
+
+function statusDotClass(status: string): string {
+  switch (status) {
+    case "RUNNING":
+    case "QUEUED":
+      return "bg-primary animate-pulse";
+    case "SUCCEEDED":
+      return "bg-emerald-500";
+    case "FAILED":
+    case "INTERNAL_ERROR":
+    case "TIMEOUT":
+      return "bg-destructive";
+    case "PAUSED":
+      return "bg-amber-500";
+    default:
+      return "bg-muted-foreground";
+  }
+}
+
+// ── FlowRunCardInner (standalone export for 8claw sidebar) ──────────────
 
 export interface FlowRunCardInnerProps {
   flowName: string;
@@ -132,7 +118,7 @@ export interface FlowRunCardInnerProps {
   durationMs?: number;
   failedStep?: string;
   onClick?: () => void;
-  highlightStyle?: CSSProperties;
+  highlightStyle?: React.CSSProperties;
 }
 
 export function FlowRunCardInner({
@@ -146,210 +132,70 @@ export function FlowRunCardInner({
   onClick,
   highlightStyle,
 }: FlowRunCardInnerProps) {
+  const [now, setNow] = useState(() => Date.now());
   const isRunning = status === "RUNNING" || status === "QUEUED";
-  const isSuccess = status === "SUCCEEDED";
-  const isError = isRunError(status);
-  const elapsed = useElapsedSeconds(startTime, isRunning);
-  const timeAgo = relativeTimeFromISO(startTime ?? finishTime);
-  const duration = formatDuration(durationMs ?? null);
 
-  if (isRunning) {
-    return (
-      <div
-        className="bg-card rounded-2xl p-5 shadow-[0_4px_12px_rgba(0,0,0,0.04)] hover:shadow-[0_8px_24px_rgba(0,0,0,0.08)] hover:-translate-y-0.5 transition-all duration-300 cursor-pointer"
-        style={highlightStyle}
-        onClick={onClick}
-      >
-        <div className="flex items-center gap-2 mb-3">
-          <span className="relative flex size-2">
-            <span className="absolute inline-flex size-full animate-ping rounded-full bg-brand-ongoing opacity-75" />
-            <span className="relative inline-flex size-2 rounded-full bg-brand-ongoing" />
-          </span>
-          <span className="flex-1 min-w-0 truncate text-[13px] font-medium text-foreground">
-            {flowName}
-          </span>
-          <span className="text-[10px] font-bold tracking-[0.1em] uppercase text-brand-ongoing">
-            Running
-          </span>
-        </div>
-        <div className="flex items-center gap-3 text-[12px] text-muted-foreground">
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            className="animate-spin text-foreground shrink-0"
-          >
-            <circle
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="3"
-              fill="none"
-              strokeDasharray="31.4 31.4"
-              strokeLinecap="round"
-            />
-          </svg>
-          <span>
-            Processing{stepsCount ? ` (${stepsCount} steps)` : ""}...
-          </span>
-        </div>
-        <div className="mt-3 pt-3 border-t border-border flex justify-between items-center">
-          <span className="text-[11px] text-muted-foreground">
-            {timeAgo || "just now"}
-          </span>
-          <span className="text-[12px] font-mono text-muted-foreground">
-            {elapsed}s
-          </span>
-        </div>
-      </div>
-    );
-  }
+  useEffect(() => {
+    if (!isRunning || !startTime) return;
+    const timer = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, [isRunning, startTime]);
 
-  if (isSuccess) {
-    return (
-      <div
-        className="bg-card rounded-2xl p-4 shadow-[0_4px_12px_rgba(0,0,0,0.04)] hover:shadow-[0_8px_24px_rgba(0,0,0,0.08)] hover:-translate-y-0.5 transition-all duration-300 cursor-pointer"
-        style={highlightStyle}
-        onClick={onClick}
-      >
-        <div className="flex items-center gap-2 mb-2">
-          <span className="size-2 rounded-full bg-brand-success-bg shrink-0" />
-          <span className="flex-1 min-w-0 truncate text-[13px] font-medium text-foreground">
-            {flowName}
-          </span>
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="text-brand-success-text shrink-0"
-          >
-            <path d="m5 13 4 4L19 7" />
-          </svg>
-        </div>
-        <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-          {stepsCount != null && (
-            <>
-              <span>{stepsCount} steps</span>
-              <span>&middot;</span>
-            </>
-          )}
-          <span>{duration}</span>
-          {timeAgo && (
-            <>
-              <span>&middot;</span>
-              <span>{timeAgo}</span>
-            </>
-          )}
-        </div>
-      </div>
-    );
-  }
+  const durationLabel = useMemo(() => {
+    if (durationMs) return formatDuration(durationMs);
+    if (isRunning && startTime) {
+      return formatDuration(Math.max(0, now - new Date(startTime).getTime()));
+    }
+    if (startTime && finishTime) {
+      return formatDuration(new Date(finishTime).getTime() - new Date(startTime).getTime());
+    }
+    return null;
+  }, [durationMs, isRunning, startTime, finishTime, now]);
 
-  if (isError) {
-    return (
-      <div
-        className="bg-card rounded-2xl p-4 border border-brand-failure/50 shadow-[0_4px_12px_rgba(0,0,0,0.04)] hover:shadow-[0_8px_24px_rgba(0,0,0,0.08)] hover:-translate-y-0.5 transition-all duration-300 cursor-pointer"
-        style={highlightStyle}
-        onClick={onClick}
-      >
-        <div className="flex items-center gap-2 mb-2">
-          <span className="size-2 rounded-full bg-brand-failure shrink-0" />
-          <span className="flex-1 min-w-0 truncate text-[13px] font-medium text-foreground">
-            {flowName}
-          </span>
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            className="text-brand-failure shrink-0"
-          >
-            <circle cx="12" cy="12" r="10" />
-            <line x1="15" y1="9" x2="9" y2="15" />
-            <line x1="9" y1="9" x2="15" y2="15" />
-          </svg>
-        </div>
-        {failedStep && (
-          <p className="text-[11px] text-[#C46C78] mb-2">
-            Failed at: {failedStep}
-          </p>
-        )}
-        <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-          {stepsCount != null && (
-            <>
-              <span>{stepsCount} steps</span>
-              <span>&middot;</span>
-            </>
-          )}
-          <span>{duration}</span>
-          {timeAgo && (
-            <>
-              <span>&middot;</span>
-              <span>{timeAgo}</span>
-            </>
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  // Other statuses (PAUSED, SCHEDULED, etc.)
   return (
     <div
-      className="bg-card rounded-2xl p-4 shadow-[0_4px_12px_rgba(0,0,0,0.04)] hover:shadow-[0_8px_24px_rgba(0,0,0,0.08)] hover:-translate-y-0.5 transition-all duration-300 cursor-pointer"
+      className="rounded-2xl border border-border bg-card/80 px-3.5 py-3 transition-shadow"
       style={highlightStyle}
       onClick={onClick}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
     >
-      <div className="flex items-center gap-2 mb-2">
-        <span className="size-2 rounded-full bg-brand-paused-bg shrink-0" />
-        <span className="flex-1 min-w-0 truncate text-[13px] font-medium text-foreground">
-          {flowName}
-        </span>
-        <span className="text-[10px] font-bold tracking-[0.1em] uppercase text-brand-paused-text">
-          {status}
-        </span>
-      </div>
-      <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-        <span>{duration}</span>
-        {timeAgo && (
-          <>
-            <span>&middot;</span>
-            <span>{timeAgo}</span>
-          </>
-        )}
+      <div className="flex items-start gap-3">
+        <div className={`mt-1 h-2.5 w-2.5 shrink-0 rounded-full ${statusDotClass(status)}`} />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium text-foreground truncate">{flowName}</span>
+            <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] border ${statusBgClass(status)}`}>
+              {status}
+            </span>
+          </div>
+
+          {failedStep && (
+            <div className="mt-1 text-xs text-destructive/80">
+              Failed at: {failedStep}
+            </div>
+          )}
+
+          <div className="mt-2 flex flex-wrap items-center gap-3 text-[11px] text-muted-foreground">
+            {durationLabel && (
+              <span className={`inline-flex items-center gap-1 ${isRunning ? statusColor(status) : ""}`}>
+                {isRunning && <span className="h-1.5 w-1.5 rounded-full bg-primary animate-pulse" />}
+                {durationLabel}
+              </span>
+            )}
+            {typeof stepsCount === "number" && stepsCount > 0 && (
+              <span>{stepsCount} step{stepsCount !== 1 ? "s" : ""}</span>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );
 }
 
-/* ── Plugin view (wraps inner with plugin infrastructure) ── */
+// ── Plugin view ─────────────────────────────────────────────────────────
 
-function FlowRunCardView({
-  state,
-  data,
-  addInputAttachment,
-}: PluginViewProps<FlowRunCardData>) {
-  if (state === "tombstone") {
-    return (
-      <div
-        data-testid="flow-run-card"
-        className="rounded-2xl border border-dashed border-border bg-card/50 px-3.5 py-3"
-      >
-        <div className="text-sm text-muted-foreground">
-          Run no longer available.
-        </div>
-      </div>
-    );
-  }
-
+function FlowRunCardView({ state, data, addInputAttachment }: PluginViewProps<FlowRunCardData>) {
   const handleClick = () => {
     addInputAttachment?.("flow_run", {
       id: data.runId,
@@ -358,23 +204,29 @@ function FlowRunCardView({
     });
   };
 
+  if (state === "tombstone") {
+    return (
+      <div className="rounded-2xl border border-dashed border-border bg-card/50 px-3.5 py-3">
+        <div className="text-sm text-muted-foreground">Run no longer available</div>
+      </div>
+    );
+  }
+
   return (
-    <div data-testid="flow-run-card">
-      <FlowRunCardInner
-        flowName={data.flowName}
-        status={data.status}
-        stepsCount={data.stepsCount}
-        startTime={data.startTime}
-        finishTime={data.finishTime}
-        durationMs={data.durationMs}
-        failedStep={data.failedStep}
-        onClick={handleClick}
-      />
-    </div>
+    <FlowRunCardInner
+      flowName={data.flowName}
+      status={data.status}
+      stepsCount={data.stepsCount}
+      startTime={data.startTime}
+      finishTime={data.finishTime}
+      durationMs={data.durationMs}
+      failedStep={data.failedStep}
+      onClick={handleClick}
+    />
   );
 }
 
-/* ── Plugin definition ── */
+// ── Plugin definition ───────────────────────────────────────────────────
 
 export const flowRunCardPlugin: MobileClawPlugin<FlowRunCardData> = {
   type: "flow_run_card",
@@ -382,10 +234,7 @@ export const flowRunCardPlugin: MobileClawPlugin<FlowRunCardData> = {
   parse: (raw) => {
     const parsed = flowRunCardSchema.safeParse(raw);
     if (!parsed.success) {
-      return {
-        ok: false,
-        error: parsed.error.issues[0]?.message || "Invalid flow run payload",
-      };
+      return { ok: false, error: parsed.error.issues[0]?.message || "Invalid flow run card payload" };
     }
     return { ok: true, value: parsed.data };
   },

--- a/plugins/app/flowRunDetailCard.tsx
+++ b/plugins/app/flowRunDetailCard.tsx
@@ -1,236 +1,155 @@
 "use client";
 
 import { z } from "zod";
+import type { MobileClawPlugin, PluginViewProps } from "@mc/lib/plugins/types";
 
-import type {
-  MobileClawPlugin,
-  PluginViewProps,
-} from "@mc/lib/plugins/types";
-import {
-  formatDuration,
-  relativeTimeFromISO,
-  isRunError,
-} from "@mc/plugins/app/flowRunCard";
+// ── Schema ──────────────────────────────────────────────────────────────────
 
-/* ── Zod schema ── */
+const stepInfoSchema = z.object({
+  status: z.string().optional(),
+  errorMessage: z.string().optional(),
+});
 
 const flowRunDetailCardSchema = z.object({
   runId: z.string(),
-  flowId: z.string(),
-  flowName: z.string().optional(),
+  flowId: z.string().optional(),
+  flowName: z.string(),
   status: z.string(),
   startTime: z.string().optional(),
   finishTime: z.string().optional(),
   durationMs: z.number().optional(),
   failedStep: z.string().nullable().optional(),
-  steps: z.record(
-    z.string(),
-    z.object({
-      status: z.string(),
-      errorMessage: z.string().optional(),
-    }),
-  ),
+  steps: z.record(z.string(), stepInfoSchema).optional(),
 });
 
 type FlowRunDetailCardData = z.infer<typeof flowRunDetailCardSchema>;
 
-/* ── Status helpers ── */
+// ── Helpers ─────────────────────────────────────────────────────────────────
 
-function stepDotClass(status: string): string {
-  if (status === "SUCCEEDED") return "bg-brand-success-bg";
-  if (status === "RUNNING") return "bg-brand-ongoing";
-  if (isRunError(status)) return "bg-brand-failure";
-  if (status === "PAUSED") return "bg-brand-paused-bg";
-  return "bg-muted-foreground/30";
+function formatDuration(ms?: number): string | null {
+  if (!ms || ms <= 0) return null;
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
 }
 
-function stepLineClass(status: string): string {
-  if (status === "SUCCEEDED") return "bg-brand-success-bg/40";
-  if (isRunError(status)) return "bg-brand-failure/40";
-  return "bg-border";
+function statusBgClass(status: string): string {
+  switch (status) {
+    case "RUNNING":
+    case "QUEUED":
+      return "border-primary/20 bg-primary/10 text-primary";
+    case "SUCCEEDED":
+      return "border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400";
+    case "FAILED":
+    case "INTERNAL_ERROR":
+    case "TIMEOUT":
+      return "border-destructive/20 bg-destructive/10 text-destructive";
+    case "PAUSED":
+      return "border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-400";
+    default:
+      return "border-border bg-background/60 text-muted-foreground";
+  }
 }
 
-function overallStatusBadge(status: string): { text: string; className: string } {
-  if (status === "SUCCEEDED")
-    return { text: "Succeeded", className: "bg-brand-success-bg/30 text-brand-success-text" };
-  if (status === "RUNNING" || status === "QUEUED")
-    return { text: "Running", className: "bg-brand-ongoing/20 text-brand-ongoing" };
-  if (isRunError(status))
-    return { text: status === "FAILED" ? "Failed" : status, className: "bg-brand-failure/20 text-brand-failure" };
-  if (status === "PAUSED")
-    return { text: "Paused", className: "bg-brand-paused-bg/30 text-brand-paused-text" };
-  return { text: status, className: "bg-secondary text-muted-foreground" };
+function stepStatusIcon(status?: string): { color: string; icon: React.ReactNode } {
+  switch (status) {
+    case "SUCCEEDED":
+      return {
+        color: "text-emerald-500",
+        icon: (
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="m5 13 4 4L19 7" />
+          </svg>
+        ),
+      };
+    case "FAILED":
+      return {
+        color: "text-destructive",
+        icon: (
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M18 6 6 18" /><path d="M6 6l12 12" />
+          </svg>
+        ),
+      };
+    case "RUNNING":
+      return {
+        color: "text-primary",
+        icon: <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />,
+      };
+    default:
+      return {
+        color: "text-muted-foreground",
+        icon: <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/40" />,
+      };
+  }
 }
 
-/* ── Shared inner component ── */
+// ── View ────────────────────────────────────────────────────────────────────
 
-export interface FlowRunDetailCardInnerProps {
-  runId: string;
-  flowName?: string;
-  status: string;
-  startTime?: string;
-  finishTime?: string;
-  durationMs?: number;
-  failedStep?: string | null;
-  steps: Record<string, { status: string; errorMessage?: string }>;
-  onClick?: () => void;
-}
+function FlowRunDetailCardView({ state, data }: PluginViewProps<FlowRunDetailCardData>) {
+  if (state === "tombstone") {
+    return (
+      <div className="rounded-2xl border border-dashed border-border bg-card/50 px-3.5 py-3">
+        <div className="text-sm text-muted-foreground">Run details no longer available</div>
+      </div>
+    );
+  }
 
-export function FlowRunDetailCardInner({
-  flowName,
-  status,
-  startTime,
-  finishTime,
-  durationMs,
-  failedStep,
-  steps,
-  onClick,
-}: FlowRunDetailCardInnerProps) {
-  const badge = overallStatusBadge(status);
-  const timeAgo = relativeTimeFromISO(startTime ?? finishTime);
-  const duration = formatDuration(durationMs ?? null);
-  const stepEntries = Object.entries(steps);
+  const stepEntries = data.steps ? Object.entries(data.steps) : [];
+  const durationLabel = formatDuration(data.durationMs);
 
   return (
-    <div
-      className="overflow-hidden rounded-[24px] bg-card border border-border/50 shadow-[0_8px_24px_rgba(0,0,0,0.06)] cursor-pointer hover:shadow-[0_12px_32px_rgba(0,0,0,0.1)] hover:-translate-y-0.5 transition-all duration-300"
-      onClick={onClick}
-    >
+    <div className="rounded-2xl border border-border bg-card/80 overflow-hidden">
       {/* Header */}
-      <div className="px-5 pt-4 pb-3">
-        <div className="flex items-center gap-2 mb-1">
-          <span className="flex-1 min-w-0 truncate text-[13px] font-medium text-foreground">
-            {flowName?.trim() || "Untitled workflow"}
-          </span>
-          <span
-            className={`shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-[9px] font-bold tracking-[0.08em] uppercase ${badge.className}`}
-          >
-            {badge.text}
+      <div className="px-3.5 py-3">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-foreground truncate">{data.flowName}</span>
+          <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] border ${statusBgClass(data.status)}`}>
+            {data.status}
           </span>
         </div>
-        <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-          <span>{duration}</span>
-          {timeAgo && (
-            <>
-              <span>&middot;</span>
-              <span>{timeAgo}</span>
-            </>
+        <div className="mt-1.5 flex items-center gap-3 text-[11px] text-muted-foreground">
+          {durationLabel && <span>{durationLabel}</span>}
+          {stepEntries.length > 0 && <span>{stepEntries.length} steps</span>}
+          {data.failedStep && (
+            <span className="text-destructive/80">failed at {data.failedStep}</span>
           )}
-          <span>&middot;</span>
-          <span>{stepEntries.length} steps</span>
         </div>
       </div>
 
-      {/* Step timeline */}
+      {/* Steps timeline */}
       {stepEntries.length > 0 && (
-        <div className="px-5 pb-4">
-          <div className="relative">
-            {stepEntries.map(([name, step], i) => {
-              const isLast = i === stepEntries.length - 1;
-              const isFailed = name === failedStep;
-
-              return (
-                <div key={name} className="flex gap-3 relative">
-                  {/* Connector line + dot */}
-                  <div className="flex flex-col items-center shrink-0 w-3">
-                    <span
-                      className={`size-2.5 rounded-full shrink-0 mt-1 ${stepDotClass(step.status)}${
-                        step.status === "RUNNING" ? " animate-pulse" : ""
-                      }`}
-                    />
-                    {!isLast && (
-                      <span
-                        className={`w-px flex-1 min-h-3 ${stepLineClass(step.status)}`}
-                      />
-                    )}
-                  </div>
-
-                  {/* Step info */}
-                  <div className={`flex-1 min-w-0 pb-2.5 ${isLast ? "pb-0" : ""}`}>
-                    <div className="flex items-center gap-2">
-                      <span
-                        className={`text-[12px] font-medium truncate ${
-                          isFailed ? "text-brand-failure" : "text-foreground"
-                        }`}
-                      >
-                        {name}
-                      </span>
-                      {step.status !== "SUCCEEDED" && (
-                        <span
-                          className={`text-[9px] font-bold tracking-[0.06em] uppercase ${
-                            isRunError(step.status)
-                              ? "text-brand-failure"
-                              : step.status === "RUNNING"
-                                ? "text-brand-ongoing"
-                                : "text-muted-foreground"
-                          }`}
-                        >
-                          {step.status}
-                        </span>
-                      )}
-                    </div>
-                    {isFailed && step.errorMessage && (
-                      <p className="text-[10px] text-brand-failure/80 mt-0.5 line-clamp-2">
-                        {step.errorMessage}
-                      </p>
-                    )}
-                  </div>
+        <div className="border-t border-border/60 px-3.5 py-2.5 max-h-[200px] overflow-y-auto">
+          {stepEntries.map(([name, info]) => {
+            const { color, icon } = stepStatusIcon(info.status);
+            const isFailed = name === data.failedStep;
+            return (
+              <div key={name} className="flex items-start gap-2.5 py-1">
+                <div className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center ${color}`}>
+                  {icon}
                 </div>
-              );
-            })}
-          </div>
+                <div className="min-w-0 flex-1">
+                  <span className={`text-xs ${isFailed ? "text-destructive font-medium" : "text-foreground"}`}>
+                    {name}
+                  </span>
+                  {isFailed && info.errorMessage && (
+                    <div className="mt-0.5 text-[10px] text-destructive/70 leading-4 line-clamp-2">
+                      {info.errorMessage}
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
         </div>
       )}
     </div>
   );
 }
 
-/* ── Plugin view ── */
-
-function FlowRunDetailCardView({
-  state,
-  data,
-  addInputAttachment,
-}: PluginViewProps<FlowRunDetailCardData>) {
-  if (state === "tombstone") {
-    return (
-      <div
-        data-testid="flow-run-detail-card"
-        className="rounded-2xl border border-dashed border-border bg-card/50 px-3.5 py-3"
-      >
-        <div className="text-sm text-muted-foreground">
-          Run detail no longer available.
-        </div>
-      </div>
-    );
-  }
-
-  const handleClick = () => {
-    addInputAttachment?.("flow_run", {
-      id: data.runId,
-      displayName: data.flowName?.trim() || "Untitled",
-      status: data.status,
-    });
-  };
-
-  return (
-    <div data-testid="flow-run-detail-card">
-      <FlowRunDetailCardInner
-        runId={data.runId}
-        flowName={data.flowName}
-        status={data.status}
-        startTime={data.startTime}
-        finishTime={data.finishTime}
-        durationMs={data.durationMs}
-        failedStep={data.failedStep}
-        steps={data.steps}
-        onClick={handleClick}
-      />
-    </div>
-  );
-}
-
-/* ── Plugin definition ── */
+// ── Plugin definition ───────────────────────────────────────────────────
 
 export const flowRunDetailCardPlugin: MobileClawPlugin<FlowRunDetailCardData> = {
   type: "flow_run_detail_card",
@@ -238,11 +157,7 @@ export const flowRunDetailCardPlugin: MobileClawPlugin<FlowRunDetailCardData> = 
   parse: (raw) => {
     const parsed = flowRunDetailCardSchema.safeParse(raw);
     if (!parsed.success) {
-      return {
-        ok: false,
-        error:
-          parsed.error.issues[0]?.message || "Invalid flow run detail payload",
-      };
+      return { ok: false, error: parsed.error.issues[0]?.message || "Invalid run detail card payload" };
     }
     return { ok: true, value: parsed.data };
   },

--- a/plugins/app/flowRunDetailCard.tsx
+++ b/plugins/app/flowRunDetailCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { z } from "zod";
 import type { MobileClawPlugin, PluginViewProps } from "@mc/lib/plugins/types";
 
@@ -53,7 +54,7 @@ function statusBgClass(status: string): string {
   }
 }
 
-function stepStatusIcon(status?: string): { color: string; icon: React.ReactNode } {
+function stepStatusIcon(status?: string): { color: string; icon: ReactNode } {
   switch (status) {
     case "SUCCEEDED":
       return {

--- a/plugins/app/flowRunListCard.tsx
+++ b/plugins/app/flowRunListCard.tsx
@@ -1,20 +1,11 @@
 "use client";
 
 import { z } from "zod";
+import type { MobileClawPlugin, PluginViewProps } from "@mc/lib/plugins/types";
 
-import type {
-  MobileClawPlugin,
-  PluginViewProps,
-} from "@mc/lib/plugins/types";
-import {
-  formatDuration,
-  relativeTimeFromISO,
-  isRunError,
-} from "@mc/plugins/app/flowRunCard";
+// ── Schema ──────────────────────────────────────────────────────────────────
 
-/* ── Zod schema ── */
-
-const runItemSchema = z.object({
+const runEntrySchema = z.object({
   runId: z.string(),
   flowId: z.string().optional(),
   flowName: z.string(),
@@ -27,249 +18,133 @@ const runItemSchema = z.object({
 });
 
 const flowRunListCardSchema = z.object({
-  runs: z.array(runItemSchema),
+  runs: z.array(runEntrySchema),
   total: z.number().optional(),
 });
 
 type FlowRunListCardData = z.infer<typeof flowRunListCardSchema>;
 
-/* ── Status helpers ── */
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatDuration(ms?: number): string | null {
+  if (!ms || ms <= 0) return null;
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}
 
 function statusDotClass(status: string): string {
-  if (status === "RUNNING" || status === "QUEUED") return "bg-brand-ongoing";
-  if (status === "SUCCEEDED") return "bg-brand-success-bg";
-  if (isRunError(status)) return "bg-brand-failure";
-  if (status === "PAUSED") return "bg-brand-paused-bg";
-  return "bg-muted-foreground/40";
+  switch (status) {
+    case "RUNNING":
+    case "QUEUED":
+      return "bg-primary animate-pulse";
+    case "SUCCEEDED":
+      return "bg-emerald-500";
+    case "FAILED":
+    case "INTERNAL_ERROR":
+    case "TIMEOUT":
+      return "bg-destructive";
+    case "PAUSED":
+      return "bg-amber-500";
+    default:
+      return "bg-muted-foreground/40";
+  }
 }
 
-function StatusIcon({ status }: { status: string }) {
-  if (status === "SUCCEEDED")
-    return (
-      <svg
-        width="12"
-        height="12"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="3"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="text-brand-success-text shrink-0"
-      >
-        <path d="m5 13 4 4L19 7" />
-      </svg>
-    );
-  if (status === "RUNNING" || status === "QUEUED")
-    return (
-      <svg
-        width="12"
-        height="12"
-        viewBox="0 0 24 24"
-        className="animate-spin text-brand-ongoing shrink-0"
-      >
-        <circle
-          cx="12"
-          cy="12"
-          r="10"
-          stroke="currentColor"
-          strokeWidth="3"
-          fill="none"
-          strokeDasharray="31.4 31.4"
-          strokeLinecap="round"
-        />
-      </svg>
-    );
-  if (isRunError(status))
-    return (
-      <svg
-        width="12"
-        height="12"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        className="text-brand-failure shrink-0"
-      >
-        <circle cx="12" cy="12" r="10" />
-        <line x1="15" y1="9" x2="9" y2="15" />
-        <line x1="9" y1="9" x2="15" y2="15" />
-      </svg>
-    );
-  if (status === "PAUSED")
-    return (
-      <svg
-        width="12"
-        height="12"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        className="text-brand-paused-text shrink-0"
-      >
-        <rect x="6" y="4" width="4" height="16" rx="1" />
-        <rect x="14" y="4" width="4" height="16" rx="1" />
-      </svg>
-    );
-  return null;
+function statusLabel(status: string): string {
+  return status.toLowerCase().replace(/_/g, " ");
 }
 
-/* ── Shared inner component ── */
-
-export interface FlowRunListCardInnerProps {
-  runs: Array<{
-    runId: string;
-    flowId?: string;
-    flowName: string;
-    status: string;
-    stepsCount?: number;
-    startTime?: string;
-    finishTime?: string;
-    durationMs?: number;
-    failedStep?: string;
-  }>;
-  total?: number;
-  onRunClick?: (runId: string) => void;
+function timeAgo(ts: string): string {
+  const diff = Date.now() - new Date(ts).getTime();
+  if (diff < 60_000) return "just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return `${Math.floor(diff / 86_400_000)}d ago`;
 }
 
-export function FlowRunListCardInner({
-  runs,
-  total,
-  onRunClick,
-}: FlowRunListCardInnerProps) {
-  const count = total ?? runs.length;
+// ── View ────────────────────────────────────────────────────────────────────
+
+function FlowRunListCardView({ state, data, addInputAttachment }: PluginViewProps<FlowRunListCardData>) {
+  if (state === "tombstone") {
+    return (
+      <div className="rounded-2xl border border-dashed border-border bg-card/50 px-3.5 py-3">
+        <div className="text-sm text-muted-foreground">Runs list no longer available</div>
+      </div>
+    );
+  }
+
+  const { runs, total } = data;
+  const hasMore = total && total > runs.length;
 
   return (
-    <div className="overflow-hidden rounded-[24px] bg-card border border-border/50 shadow-[0_8px_24px_rgba(0,0,0,0.06)]">
+    <div className="rounded-2xl border border-border bg-card/80 overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between px-5 pt-4 pb-2">
-        <span className="text-[10px] font-bold tracking-[0.12em] uppercase text-muted-foreground">
-          Flow Runs
-        </span>
-        <span className="text-[11px] text-muted-foreground/60">
-          {count} run{count !== 1 ? "s" : ""}
-        </span>
+      <div className="px-3.5 py-2.5 border-b border-border/60">
+        <div className="flex items-center gap-2">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className="text-muted-foreground shrink-0">
+            <path d="M12 2v4" /><path d="m16.2 7.8 2.9-2.9" />
+            <path d="M18 12h4" /><path d="m16.2 16.2 2.9 2.9" />
+            <path d="M12 18v4" /><path d="m4.9 19.1 2.9-2.9" />
+            <path d="M2 12h4" /><path d="m4.9 4.9 2.9 2.9" />
+          </svg>
+          <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+            Runs{total ? ` (${total})` : ""}
+          </span>
+        </div>
       </div>
 
-      {/* Run items */}
-      <div className="divide-y divide-border/40">
-        {runs.map((run) => {
-          const timeAgo = relativeTimeFromISO(run.startTime ?? run.finishTime);
-          const duration = formatDuration(run.durationMs ?? null);
-
-          return (
-            <div
-              key={run.runId}
-              className="flex items-center gap-3 px-5 py-3 transition-colors hover:bg-accent/30 cursor-pointer"
-              onClick={() => onRunClick?.(run.runId)}
-            >
-              {/* Status dot */}
-              <span
-                className={`size-2 rounded-full shrink-0 ${statusDotClass(run.status)}`}
-              />
-
-              {/* Name + details */}
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="text-[13px] font-medium text-foreground truncate">
-                    {run.flowName}
-                  </span>
-                  {run.status !== "SUCCEEDED" && (
-                    <span
-                      className={`shrink-0 text-[9px] font-bold tracking-[0.08em] uppercase ${
-                        run.status === "RUNNING" || run.status === "QUEUED"
-                          ? "text-brand-ongoing"
-                          : isRunError(run.status)
-                            ? "text-brand-failure"
-                            : run.status === "PAUSED"
-                              ? "text-brand-paused-text"
-                              : "text-muted-foreground"
-                      }`}
-                    >
-                      {run.status}
-                    </span>
-                  )}
-                </div>
-                <div className="flex items-center gap-1.5 mt-0.5 text-[11px] text-muted-foreground">
-                  <span>{duration}</span>
-                  {run.stepsCount != null && (
-                    <>
-                      <span>&middot;</span>
-                      <span>{run.stepsCount} steps</span>
-                    </>
-                  )}
-                  {timeAgo && (
-                    <>
-                      <span>&middot;</span>
-                      <span>{timeAgo}</span>
-                    </>
-                  )}
-                </div>
+      {/* List */}
+      <div className="max-h-[320px] overflow-y-auto">
+        {runs.map((run, i) => (
+          <div
+            key={run.runId}
+            className={`px-3.5 py-2.5 flex items-start gap-3 transition-colors hover:bg-secondary/30 cursor-pointer ${
+              i < runs.length - 1 ? "border-b border-border/40" : ""
+            }`}
+            onClick={() => {
+              addInputAttachment?.("flow_run", {
+                id: run.runId,
+                displayName: run.flowName,
+                status: run.status,
+              });
+            }}
+            role="button"
+            tabIndex={0}
+          >
+            <div className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${statusDotClass(run.status)}`} />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-foreground truncate">{run.flowName}</span>
+                <span className="text-[10px] text-muted-foreground">{statusLabel(run.status)}</span>
+              </div>
+              <div className="flex items-center gap-2 mt-0.5 text-[10px] text-muted-foreground">
+                {run.startTime && <span>{timeAgo(run.startTime)}</span>}
+                {run.durationMs && <span>{formatDuration(run.durationMs)}</span>}
                 {run.failedStep && (
-                  <p className="text-[10px] text-brand-failure mt-0.5 truncate">
-                    Failed at: {run.failedStep}
-                  </p>
+                  <span className="text-destructive/80">failed at {run.failedStep}</span>
                 )}
               </div>
-
-              {/* Status icon */}
-              <StatusIcon status={run.status} />
             </div>
-          );
-        })}
+          </div>
+        ))}
       </div>
 
-      {/* Show more indicator */}
-      {total != null && total > runs.length && (
-        <div className="px-5 py-2.5 text-center text-[11px] text-muted-foreground/60 border-t border-border/40">
-          +{total - runs.length} more
+      {/* Footer */}
+      {hasMore && (
+        <div className="px-3.5 py-2 border-t border-border/60">
+          <span className="text-[10px] text-muted-foreground">
+            +{total! - runs.length} more
+          </span>
         </div>
       )}
     </div>
   );
 }
 
-/* ── Plugin view ── */
-
-function FlowRunListCardView({
-  state,
-  data,
-  addInputAttachment,
-}: PluginViewProps<FlowRunListCardData>) {
-  if (state === "tombstone") {
-    return (
-      <div
-        data-testid="flow-run-list-card"
-        className="rounded-2xl border border-dashed border-border bg-card/50 px-3.5 py-3"
-      >
-        <div className="text-sm text-muted-foreground">
-          Flow runs list no longer available.
-        </div>
-      </div>
-    );
-  }
-
-  const handleRunClick = (runId: string) => {
-    const run = data.runs.find((r) => r.runId === runId);
-    addInputAttachment?.("flow_run", {
-      id: runId,
-      displayName: run?.flowName ?? "Untitled",
-      status: run?.status ?? "UNKNOWN",
-    });
-  };
-
-  return (
-    <div data-testid="flow-run-list-card">
-      <FlowRunListCardInner
-        runs={data.runs}
-        total={data.total}
-        onRunClick={handleRunClick}
-      />
-    </div>
-  );
-}
-
-/* ── Plugin definition ── */
+// ── Plugin definition ───────────────────────────────────────────────────
 
 export const flowRunListCardPlugin: MobileClawPlugin<FlowRunListCardData> = {
   type: "flow_run_list_card",
@@ -277,11 +152,7 @@ export const flowRunListCardPlugin: MobileClawPlugin<FlowRunListCardData> = {
   parse: (raw) => {
     const parsed = flowRunListCardSchema.safeParse(raw);
     if (!parsed.success) {
-      return {
-        ok: false,
-        error:
-          parsed.error.issues[0]?.message || "Invalid flow run list payload",
-      };
+      return { ok: false, error: parsed.error.issues[0]?.message || "Invalid run list card payload" };
     }
     return { ok: true, value: parsed.data };
   },

--- a/plugins/app/index.ts
+++ b/plugins/app/index.ts
@@ -1,31 +1,23 @@
 import type { AnyMobileClawPlugin } from "@mc/lib/plugins/types";
 import type { AnyInputAttachmentPlugin } from "@mc/lib/plugins/inputAttachmentTypes";
 import { contextChipPlugin, promptContextAttachmentPlugin } from "@mc/plugins/app/contextChip";
-import { flowRunAttachmentPlugin } from "@mc/plugins/app/flowRunChip";
-import { connectionAttachmentPlugin } from "@mc/plugins/app/connectionChip";
-import { flowListCardPlugin } from "@mc/plugins/app/flowListCard";
+import { notificationCardPlugin } from "@mc/plugins/app/notificationCard";
 import { flowRunCardPlugin } from "@mc/plugins/app/flowRunCard";
+import { flowListCardPlugin } from "@mc/plugins/app/flowListCard";
 import { flowRunListCardPlugin } from "@mc/plugins/app/flowRunListCard";
 import { flowRunDetailCardPlugin } from "@mc/plugins/app/flowRunDetailCard";
-import { connectionListCardPlugin } from "@mc/plugins/app/connectionListCard";
-import { notificationCardPlugin } from "@mc/plugins/app/notificationCard";
-import { pauseCardPlugin } from "@mc/plugins/app/pauseCard";
-import { tourProgressPlugin } from "./TourProgressPlugin";
+import { flowCanvasCardPlugin } from "@mc/plugins/app/flowCanvasCard";
 
 export const appPlugins: AnyMobileClawPlugin[] = [
   contextChipPlugin,
-  tourProgressPlugin,
   notificationCardPlugin,
-  pauseCardPlugin,
   flowRunCardPlugin,
+  flowListCardPlugin,
   flowRunListCardPlugin,
   flowRunDetailCardPlugin,
-  flowListCardPlugin,
-  connectionListCardPlugin,
+  flowCanvasCardPlugin,
 ];
 
 export const appInputAttachmentPlugins: AnyInputAttachmentPlugin[] = [
   promptContextAttachmentPlugin,
-  flowRunAttachmentPlugin,
-  connectionAttachmentPlugin,
 ];

--- a/plugins/app/notificationCard.tsx
+++ b/plugins/app/notificationCard.tsx
@@ -1,18 +1,11 @@
 "use client";
 
-import { type ReactNode, useEffect, useState } from "react";
-
+import { useState } from "react";
 import { z } from "zod";
+import type { MobileClawPlugin, PluginViewProps } from "@mc/lib/plugins/types";
+import type { PluginAction, PluginActionStyle } from "@mc/types/chat";
 
-import type { PluginAction } from "@mc/types/chat";
-import type {
-  MobileClawPlugin,
-  PluginParseResult,
-  PluginViewProps,
-} from "@mc/lib/plugins/types";
-import { InlineMarkdown } from "@mc/components/markdown/MarkdownContent";
-
-/* ── Zod schema ── */
+// ── Schema ──────────────────────────────────────────────────────────────────
 
 const optionSchema = z.object({
   label: z.string(),
@@ -26,124 +19,32 @@ const notificationCardSchema = z.object({
   question: z.string(),
   context: z.string().optional(),
   target: z.enum(["agent", "user"]),
-  urgency: z.enum(["high", "low"]),
+  urgency: z.enum(["high", "low"]).default("low"),
   mode: z.enum(["blocking", "notify"]).optional(),
-  createdAt: z.number(),
-  options: z.array(optionSchema),
+  createdAt: z.number().optional(),
+  options: z.array(optionSchema).default([]),
   resolvedLabel: z.string().optional(),
-  resolvedValue: z.string().optional(),
 });
 
-type NotificationCardInput = z.infer<typeof notificationCardSchema>;
+type NotificationCardData = z.infer<typeof notificationCardSchema>;
 
-/* ── Parsed data with actions ── */
+// ── Helpers ─────────────────────────────────────────────────────────────────
 
-type NotificationCardOption = {
-  id: string;
-  label: string;
-  value: string;
-  style?: "primary" | "secondary" | "destructive";
-  action: PluginAction;
-};
-
-type NotificationCardData = {
-  notificationId: string;
-  flowName?: string;
-  question: string;
-  context?: string;
-  target: "agent" | "user";
-  urgency: "high" | "low";
-  mode?: "blocking" | "notify";
-  createdAt: number;
-  options: NotificationCardOption[];
-  dismissAction: PluginAction;
-  resolvedLabel?: string;
-  resolvedValue?: string;
-};
-
-/* ── Parse: normalize options into actions ── */
-
-function normalizeNotificationData(
-  raw: NotificationCardInput,
-): PluginParseResult<NotificationCardData> {
-  const baseUrl = `/api/notifications/${raw.notificationId}`;
-
-  const options: NotificationCardOption[] = raw.options.map((opt, i) => ({
-    id: `option-${i}`,
-    label: opt.label,
-    value: opt.value,
-    style: opt.style,
-    action: {
-      id: `resolve-${i}`,
-      label: opt.label,
-      style: opt.style,
-      request: {
-        kind: "http" as const,
-        method: "POST" as const,
-        url: `${baseUrl}/resolve`,
-        body: { label: opt.label, value: opt.value },
-      },
-    },
-  }));
-
-  const dismissAction: PluginAction = {
-    id: "dismiss",
-    label: "Dismiss",
-    request: {
-      kind: "http" as const,
-      method: "POST" as const,
-      url: `${baseUrl}/dismiss`,
-      fireAndForget: true,
-    },
-  };
-
-  return {
-    ok: true,
-    value: {
-      notificationId: raw.notificationId,
-      flowName: raw.flowName,
-      question: raw.question,
-      context: raw.context,
-      target: raw.target,
-      urgency: raw.urgency,
-      mode: raw.mode,
-      createdAt: raw.createdAt,
-      options,
-      dismissAction,
-      resolvedLabel: raw.resolvedLabel,
-      resolvedValue: raw.resolvedValue,
-    },
-  };
+function timeAgo(ts: number): string {
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return "just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return `${Math.floor(diff / 86_400_000)}d ago`;
 }
 
-/* ── Relative time helper ── */
-
-const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
-
-export function relativeTimeFromEpoch(ts: number): string {
-  const diffMs = ts - Date.now();
-  const absMs = Math.abs(diffMs);
-  if (absMs < 60_000) return rtf.format(Math.round(diffMs / 1_000), "second");
-  if (absMs < 3_600_000)
-    return rtf.format(Math.round(diffMs / 60_000), "minute");
-  if (absMs < 86_400_000)
-    return rtf.format(Math.round(diffMs / 3_600_000), "hour");
-  return rtf.format(Math.round(diffMs / 86_400_000), "day");
+function optionToneClass(style: PluginActionStyle | undefined) {
+  if (style === "primary") return "text-primary";
+  if (style === "destructive") return "text-destructive";
+  return "text-muted-foreground";
 }
 
-function useRelativeTime(ts: number): string {
-  const [, tick] = useState(0);
-  useEffect(() => {
-    const absMs = Math.abs(ts - Date.now());
-    const ms =
-      absMs < 60_000 ? 1_000 : absMs < 3_600_000 ? 30_000 : 60_000;
-    const id = setInterval(() => tick((n) => n + 1), ms);
-    return () => clearInterval(id);
-  }, [ts]);
-  return relativeTimeFromEpoch(ts);
-}
-
-/* ── Shared inner component ── */
+// ── NotificationCardInner (standalone export for 8claw sidebar) ─────────
 
 export interface NotificationCardInnerProps {
   flowName?: string;
@@ -151,18 +52,15 @@ export interface NotificationCardInnerProps {
   context?: string;
   urgency: "high" | "low";
   mode?: "blocking" | "notify";
-  createdAt: number;
-  options: Array<{
-    label: string;
-    value: string;
-    style?: "primary" | "secondary" | "destructive";
-  }>;
+  createdAt?: number;
+  options: Array<{ label: string; value: string; style?: "primary" | "secondary" | "destructive" }>;
   resolving?: boolean;
+  onResolve?: (label: string, value: string) => void;
+  renderMarkdown?: (text: string) => React.ReactNode;
+  // For settled state
   resolved?: boolean;
   resolvedLabel?: string;
   status?: string;
-  onResolve?: (label: string, value: string) => void;
-  renderMarkdown?: (text: string) => ReactNode;
 }
 
 export function NotificationCardInner({
@@ -174,296 +72,211 @@ export function NotificationCardInner({
   createdAt,
   options,
   resolving,
+  onResolve,
+  renderMarkdown,
   resolved,
   resolvedLabel,
   status,
-  onResolve,
-  renderMarkdown,
 }: NotificationCardInnerProps) {
-  const [expanded, setExpanded] = useState(false);
-  const timeAgo = useRelativeTime(createdAt);
-  const isHigh = urgency === "high";
-  const isNotify = mode === "notify" || options.length === 0;
-  const primary = isNotify
-    ? null
-    : options.find((o) => o.style === "primary" || !o.style);
-  const rest = isNotify ? [] : options.filter((o) => o !== primary);
+  const isBlocking = mode === "blocking";
+  const isHighUrgency = urgency === "high";
+  const isSettled = resolved || status === "resolved" || status === "rejected" || status === "expired";
 
-  const md = (text: string) =>
-    renderMarkdown ? renderMarkdown(text) : <InlineMarkdown text={text} />;
-
-  if (resolved) {
-    return (
-      <div className="bg-card rounded-2xl p-6 shadow-[0_4px_12px_rgba(0,0,0,0.04)] opacity-75">
-        <div className="flex items-center gap-2 mb-3 text-[10px] font-bold tracking-[0.1em] uppercase text-muted-foreground">
-          <span className="w-1.5 h-1.5 rounded-full bg-foreground/20" />
-          <span className="flex-1">
-            {flowName?.trim() || "Workflow"}
-          </span>
-          {status && (
-            <span
-              className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium capitalize ${
-                status === "resolved"
-                  ? "bg-brand-success-bg/30 text-brand-success-text"
-                  : status === "rejected"
-                    ? "bg-brand-failure/30 text-foreground/80"
-                    : status === "expired"
-                      ? "bg-zinc-100 text-zinc-500"
-                      : "bg-secondary text-muted-foreground"
-              }`}
-            >
-              {status}
-            </span>
-          )}
-          <span className="font-normal normal-case tracking-normal text-muted-foreground/60">
-            {timeAgo}
-          </span>
-        </div>
-
-        <div
-          className="relative cursor-pointer"
-          onClick={() => setExpanded((v) => !v)}
-        >
-          <div
-            className={`text-[13px] leading-relaxed text-foreground/70 break-words overflow-hidden ${expanded ? "" : "max-h-[9em]"}`}
-          >
-            {md(question)}
-          </div>
-
-          {expanded && context && (
-            <div className="text-[13px] text-muted-foreground mt-1 break-words overflow-hidden">
-              {md(context)}
-            </div>
-          )}
-
-          {!expanded && (
-            <div className="absolute bottom-0 left-0 right-0 h-5 bg-gradient-to-t from-card to-transparent pointer-events-none" />
-          )}
-        </div>
-
-        {resolvedLabel && (
-          <div className="mt-2 text-[11px] text-muted-foreground">
-            Resolved:{" "}
-            <span className="font-medium text-foreground/70">
-              {resolvedLabel}
-            </span>
-          </div>
-        )}
-      </div>
-    );
-  }
+  const borderClass = isSettled
+    ? "border-dashed border-border"
+    : isHighUrgency
+      ? "border-destructive/30"
+      : "border-border";
 
   return (
-    <div className="bg-card rounded-2xl p-6 shadow-[0_4px_12px_rgba(0,0,0,0.04)] hover:shadow-[0_8px_24px_rgba(0,0,0,0.08)] hover:-translate-y-0.5 transition-all duration-300">
-      <div className="flex items-center gap-2 mb-3 text-[10px] font-bold tracking-[0.1em] uppercase text-muted-foreground">
-        <span
-          className={`w-1.5 h-1.5 rounded-full ${isHigh ? "bg-foreground" : "bg-foreground/30"}`}
-        />
-        <span className="flex-1">
-          {flowName?.trim() || "Workflow"}
-        </span>
-        {!isNotify && (
-          <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium capitalize bg-amber-100 text-amber-800">
-            pending
-          </span>
-        )}
-        <span className="font-normal normal-case tracking-normal text-muted-foreground/60">
-          {timeAgo}
-        </span>
-      </div>
-
-      <div
-        className="relative cursor-pointer"
-        onClick={() => setExpanded((v) => !v)}
-      >
-        <div
-          className={`text-[13px] leading-relaxed text-foreground break-words overflow-hidden ${expanded ? "" : "max-h-[9em]"}`}
-        >
-          {md(question)}
+    <div className={`rounded-2xl border ${borderClass} bg-card/80 px-3.5 py-3`}>
+      {/* Header */}
+      <div className="flex items-start gap-3">
+        <div className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center ${
+          isSettled ? "text-muted-foreground" : isHighUrgency ? "text-destructive" : "text-primary"
+        }`}>
+          {isSettled ? (
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m5 13 4 4L19 7" />
+            </svg>
+          ) : isHighUrgency ? (
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+              <path d="M12 9v4" /><path d="M12 17h.01" />
+            </svg>
+          ) : (
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+              <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+            </svg>
+          )}
         </div>
-
-        {context && (
-          <div
-            className={`text-[13px] text-muted-foreground break-words overflow-hidden ${expanded ? "mt-1" : "max-h-[9em] mt-0.5"}`}
-          >
-            {md(context)}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            {flowName && (
+              <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                {flowName}
+              </span>
+            )}
+            {createdAt && (
+              <span className="text-[10px] text-muted-foreground/60">
+                {timeAgo(createdAt)}
+              </span>
+            )}
           </div>
-        )}
-
-        {!expanded && (
-          <div className="absolute bottom-0 left-0 right-0 h-5 bg-gradient-to-t from-card to-transparent pointer-events-none" />
-        )}
+          <div className="mt-1 text-sm leading-6 text-foreground">
+            {renderMarkdown ? renderMarkdown(question) : question}
+          </div>
+          {context && (
+            <div className="mt-1.5 text-xs leading-5 text-muted-foreground">
+              {renderMarkdown ? renderMarkdown(context) : context}
+            </div>
+          )}
+        </div>
       </div>
 
-      <button
-        onClick={() => setExpanded((v) => !v)}
-        className="text-[10px] text-muted-foreground/60 hover:text-muted-foreground transition-colors mb-3 mt-1"
-      >
-        {expanded ? "Show less" : "Show more"}
-      </button>
+      {/* Settled indicator */}
+      {isSettled && resolvedLabel && (
+        <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1.5">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m5 13 4 4L19 7" />
+            </svg>
+            {resolvedLabel}
+          </span>
+        </div>
+      )}
 
-      <div className="flex flex-col gap-2">
-        {isNotify ? (
+      {isSettled && status === "rejected" && (
+        <div className="mt-2 text-xs text-destructive/80">Rejected</div>
+      )}
+
+      {isSettled && status === "expired" && (
+        <div className="mt-2 text-xs text-muted-foreground/60">Expired</div>
+      )}
+
+      {/* Action buttons (only when pending) */}
+      {!isSettled && options.length > 0 && isBlocking && (
+        <div className="mt-3 -mx-3.5 border-t border-border/80">
+          {options.map((option, i) => (
+            <button
+              key={`${option.value}-${i}`}
+              type="button"
+              disabled={resolving}
+              onClick={() => onResolve?.(option.label, option.value)}
+              className={[
+                "group w-full border-t border-border/70 px-3.5 py-2.5 text-left text-sm font-medium transition-colors first:border-t-0",
+                resolving ? "cursor-not-allowed opacity-60" : "hover:bg-secondary/45",
+              ].join(" ")}
+            >
+              <div className="flex items-center gap-3">
+                <div className={`flex h-5 w-5 shrink-0 items-center justify-center ${optionToneClass(option.style)}`}>
+                  {option.style === "destructive" ? (
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M18 6 6 18" /><path d="M6 6l12 12" />
+                    </svg>
+                  ) : option.style === "primary" ? (
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M5 12h14" /><path d="m12 5 7 7-7 7" />
+                    </svg>
+                  ) : (
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                      <circle cx="12" cy="12" r="8" />
+                    </svg>
+                  )}
+                </div>
+                <span className="min-w-0 flex-1">{option.label}</span>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Dismiss button for notify mode */}
+      {!isSettled && mode === "notify" && (
+        <div className="mt-3 -mx-3.5 border-t border-border/80">
           <button
+            type="button"
             disabled={resolving}
             onClick={() => onResolve?.("dismissed", "dismissed")}
-            className="w-full rounded-full border border-border bg-background py-2.5 px-4 text-[11px] font-medium text-muted-foreground transition-colors duration-200 hover:bg-accent hover:text-accent-foreground disabled:opacity-50 flex items-center justify-center gap-2"
+            className="w-full px-3.5 py-2.5 text-left text-sm font-medium text-muted-foreground transition-colors hover:bg-secondary/45 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            {resolving && (
-              <svg
-                width="12"
-                height="12"
-                viewBox="0 0 24 24"
-                className="animate-spin"
-              >
-                <circle
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="3"
-                  fill="none"
-                  strokeDasharray="31.4 31.4"
-                  strokeLinecap="round"
-                />
-              </svg>
-            )}
-            Dismiss
-          </button>
-        ) : (
-          <>
-            {primary && (
-              <button
-                disabled={resolving}
-                onClick={() => onResolve?.(primary.label, primary.value)}
-                className="w-full rounded-full border border-border bg-background py-2.5 px-4 text-[11px] font-medium text-foreground transition-colors duration-200 hover:bg-accent hover:text-accent-foreground disabled:opacity-50 flex items-center justify-center gap-2"
-              >
-                {resolving && (
-                  <svg
-                    width="12"
-                    height="12"
-                    viewBox="0 0 24 24"
-                    className="animate-spin"
-                  >
-                    <circle
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="3"
-                      fill="none"
-                      strokeDasharray="31.4 31.4"
-                      strokeLinecap="round"
-                    />
-                  </svg>
-                )}
-                {primary.label}
-              </button>
-            )}
-            {rest.length > 0 && (
-              <div className="flex gap-2">
-                {rest.map((opt) => (
-                  <button
-                    key={opt.value}
-                    disabled={resolving}
-                    onClick={() => onResolve?.(opt.label, opt.value)}
-                    className={`flex-1 rounded-full py-2 px-4 text-[11px] font-medium transition-colors disabled:opacity-50 ${
-                      opt.style === "destructive"
-                        ? "text-destructive hover:text-destructive/80"
-                        : "text-muted-foreground hover:text-foreground"
-                    }`}
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-                <button
-                  disabled={resolving}
-                  onClick={() => onResolve?.("dismissed", "dismissed")}
-                  className="flex-1 rounded-full py-2 px-4 text-[11px] font-medium text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
-                >
-                  Dismiss
-                </button>
+            <div className="flex items-center gap-3">
+              <div className="flex h-5 w-5 shrink-0 items-center justify-center text-muted-foreground">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M18 6 6 18" /><path d="M6 6l12 12" />
+                </svg>
               </div>
-            )}
-          </>
-        )}
-      </div>
+              <span>Dismiss</span>
+            </div>
+          </button>
+        </div>
+      )}
     </div>
   );
 }
 
-/* ── Plugin view (wraps inner with plugin infrastructure) ── */
+// ── Plugin view (for chat stream rendering) ─────────────────────────────
 
-function NotificationCardView({
-  state,
-  data,
-  invokeAction,
-}: PluginViewProps<NotificationCardData>) {
-  const [resolving, setResolving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+function NotificationCardView({ state, data, invokeAction }: PluginViewProps<NotificationCardData>) {
+  const [submittingLabel, setSubmittingLabel] = useState<string | null>(null);
+  const [localResolvedLabel, setLocalResolvedLabel] = useState<string | null>(null);
 
-  const isResolved = state === "settled" || !!data.resolvedLabel;
+  const resolvedLabel = data.resolvedLabel || localResolvedLabel;
+  const isSettled = state === "settled" || state === "tombstone" || !!resolvedLabel;
 
   const handleResolve = async (label: string, value: string) => {
-    const isDismiss = label === "dismissed" && value === "dismissed";
-    const action = isDismiss
-      ? data.dismissAction
-      : data.options.find((o) => o.label === label && o.value === value)
-          ?.action;
-    if (!action) return;
-
-    setResolving(true);
-    setError(null);
+    setSubmittingLabel(label);
     try {
-      await invokeAction(action, {
-        selectedLabel: label,
-        selectedValue: value,
-      });
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Unable to submit selection.",
-      );
+      const isDismiss = label === "dismissed" && value === "dismissed";
+      const url = isDismiss
+        ? `/api/notifications/${data.notificationId}/dismiss`
+        : `/api/notifications/${data.notificationId}/resolve`;
+      const action: PluginAction = {
+        id: `resolve-${data.notificationId}`,
+        label,
+        request: {
+          kind: "http",
+          method: "POST",
+          url,
+          body: isDismiss ? undefined : { label, value },
+        },
+      };
+      await invokeAction(action, { selectedLabel: label, selectedValue: value });
+      setLocalResolvedLabel(label);
+    } catch {
+      // invokeAction handles error display
     } finally {
-      setResolving(false);
+      setSubmittingLabel(null);
     }
   };
 
   if (state === "tombstone") {
     return (
-      <div
-        data-testid="notification-card"
-        className="rounded-2xl border border-dashed border-border bg-card/50 px-3.5 py-3"
-      >
-        <div className="text-sm text-muted-foreground">
-          Notification expired.
-        </div>
+      <div className="rounded-2xl border border-dashed border-border bg-card/50 px-3.5 py-3">
+        <div className="text-sm text-muted-foreground">Notification dismissed</div>
       </div>
     );
   }
 
   return (
-    <div data-testid="notification-card">
-      {error && (
-        <div className="mb-2 text-xs text-destructive">{error}</div>
-      )}
-      <NotificationCardInner
-        flowName={data.flowName}
-        question={data.question}
-        context={data.context}
-        urgency={data.urgency}
-        mode={data.mode}
-        createdAt={data.createdAt}
-        options={data.options}
-        resolving={resolving}
-        resolved={isResolved}
-        resolvedLabel={data.resolvedLabel}
-        onResolve={handleResolve}
-      />
-    </div>
+    <NotificationCardInner
+      flowName={data.flowName}
+      question={data.question}
+      context={data.context}
+      urgency={data.urgency}
+      mode={data.mode}
+      createdAt={data.createdAt}
+      options={data.options}
+      resolving={!!submittingLabel}
+      onResolve={handleResolve}
+      resolved={isSettled}
+      resolvedLabel={resolvedLabel ?? undefined}
+    />
   );
 }
 
-/* ── Plugin definition ── */
+// ── Plugin definition ───────────────────────────────────────────────────
 
 export const notificationCardPlugin: MobileClawPlugin<NotificationCardData> = {
   type: "notification_card",
@@ -471,13 +284,9 @@ export const notificationCardPlugin: MobileClawPlugin<NotificationCardData> = {
   parse: (raw) => {
     const parsed = notificationCardSchema.safeParse(raw);
     if (!parsed.success) {
-      return {
-        ok: false,
-        error:
-          parsed.error.issues[0]?.message || "Invalid notification payload",
-      };
+      return { ok: false, error: parsed.error.issues[0]?.message || "Invalid notification card payload" };
     }
-    return normalizeNotificationData(parsed.data);
+    return { ok: true, value: parsed.data };
   },
   render: (props) => <NotificationCardView {...props} />,
 };

--- a/plugins/app/notificationCard.tsx
+++ b/plugins/app/notificationCard.tsx
@@ -221,17 +221,25 @@ export function NotificationCardInner({
         </div>
 
         <div
-          className={`text-[13px] leading-relaxed text-foreground/70 mb-1 cursor-pointer ${expanded ? "" : "line-clamp-2"}`}
+          className="relative cursor-pointer"
           onClick={() => setExpanded((v) => !v)}
         >
-          {md(question)}
-        </div>
-
-        {expanded && context && (
-          <div className="text-[13px] text-muted-foreground mb-1">
-            {md(context)}
+          <div
+            className={`text-[13px] leading-relaxed text-foreground/70 break-words overflow-hidden ${expanded ? "" : "max-h-[9em]"}`}
+          >
+            {md(question)}
           </div>
-        )}
+
+          {expanded && context && (
+            <div className="text-[13px] text-muted-foreground mt-1 break-words overflow-hidden">
+              {md(context)}
+            </div>
+          )}
+
+          {!expanded && (
+            <div className="absolute bottom-0 left-0 right-0 h-5 bg-gradient-to-t from-card to-transparent pointer-events-none" />
+          )}
+        </div>
 
         {resolvedLabel && (
           <div className="mt-2 text-[11px] text-muted-foreground">
@@ -254,33 +262,42 @@ export function NotificationCardInner({
         <span className="flex-1">
           {flowName?.trim() || "Workflow"}
         </span>
-        <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium capitalize bg-amber-100 text-amber-800">
-          pending
-        </span>
+        {!isNotify && (
+          <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium capitalize bg-amber-100 text-amber-800">
+            pending
+          </span>
+        )}
         <span className="font-normal normal-case tracking-normal text-muted-foreground/60">
           {timeAgo}
         </span>
       </div>
 
       <div
-        className={`text-[13px] leading-relaxed text-foreground mb-1 cursor-pointer ${expanded ? "" : "line-clamp-3"}`}
+        className="relative cursor-pointer"
         onClick={() => setExpanded((v) => !v)}
       >
-        {md(question)}
-      </div>
-
-      {context && (
         <div
-          className={`text-[13px] text-muted-foreground mb-1 cursor-pointer ${expanded ? "" : "line-clamp-2"}`}
-          onClick={() => setExpanded((v) => !v)}
+          className={`text-[13px] leading-relaxed text-foreground break-words overflow-hidden ${expanded ? "" : "max-h-[9em]"}`}
         >
-          {md(context)}
+          {md(question)}
         </div>
-      )}
+
+        {context && (
+          <div
+            className={`text-[13px] text-muted-foreground break-words overflow-hidden ${expanded ? "mt-1" : "max-h-[9em] mt-0.5"}`}
+          >
+            {md(context)}
+          </div>
+        )}
+
+        {!expanded && (
+          <div className="absolute bottom-0 left-0 right-0 h-5 bg-gradient-to-t from-card to-transparent pointer-events-none" />
+        )}
+      </div>
 
       <button
         onClick={() => setExpanded((v) => !v)}
-        className="text-[10px] text-muted-foreground/60 hover:text-muted-foreground transition-colors mb-3"
+        className="text-[10px] text-muted-foreground/60 hover:text-muted-foreground transition-colors mb-3 mt-1"
       >
         {expanded ? "Show less" : "Show more"}
       </button>

--- a/plugins/app/notificationCard.tsx
+++ b/plugins/app/notificationCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { z } from "zod";
 import type { MobileClawPlugin, PluginViewProps } from "@mc/lib/plugins/types";
 import type { PluginAction, PluginActionStyle } from "@mc/types/chat";
@@ -56,7 +56,7 @@ export interface NotificationCardInnerProps {
   options: Array<{ label: string; value: string; style?: "primary" | "secondary" | "destructive" }>;
   resolving?: boolean;
   onResolve?: (label: string, value: string) => void;
-  renderMarkdown?: (text: string) => React.ReactNode;
+  renderMarkdown?: (text: string) => ReactNode;
   // For settled state
   resolved?: boolean;
   resolvedLabel?: string;


### PR DESCRIPTION
## Summary
- Add 6 new MobileClaw plugins that render interactive cards inline in the chat stream:
  - `notification_card`: decision/inform/repair cards for stop points
  - `flow_run_card`: live run status with timer and status badges
  - `flow_list_card`: compact flow list with status indicators
  - `flow_run_list_card`: compact runs list with status and timing
  - `flow_run_detail_card`: run detail with step-by-step timeline
  - `flow_canvas`: miniature flow visualization with step nodes
- All plugins follow the existing plugin architecture (zod schema, parse, render) and export standalone Inner components for reuse in 8claw sidebar columns

## Test plan
- [ ] Verify each plugin renders correctly inline in chat
- [ ] Test notification_card with decision/inform/repair modes
- [ ] Test flow_run_card live status updates
- [ ] Verify Inner component exports work for sidebar reuse